### PR TITLE
feat(comment) : 댓글 수정 api 구현

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/controller/CommentController.java
@@ -42,4 +42,16 @@ public class CommentController {
         return ApiResponse.success(HttpStatus.OK, "댓글 조회에 성공하였습니다.", responseDto);
     }
 
+    @PutMapping("/boards/{boardId}/comments/{commentId}")
+    public ResponseEntity<ApiResponse<CommentResponseDto>> updateComment(
+            @PathVariable Long boardId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserPrincipal authUser
+    ){
+        CommentResponseDto responseDto = commentService.updateComment(boardId, commentId, requestDto, authUser);
+
+        return ApiResponse.success(HttpStatus.OK, "댓글 수정이 완료되었습니다.", responseDto);
+    }
+
 }

--- a/src/main/java/com/example/workoutmate/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/repository/CommentRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByBoardId(Long boardId);
+
+    Optional<Comment> findById(Long commentId);
 }

--- a/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
@@ -58,12 +58,14 @@ public class CommentService {
         Board board = boardService.getBoardById(boardId);
         Comment comment = findById(commentId);
 
+        // 해당 댓글이 요청받은 board에 속한 댓글인지 검증
         if (!comment.getBoard().getId().equals(board.getId())){
             throw new CustomException(COMMENT_NOT_IN_BOARD, COMMENT_NOT_IN_BOARD.getMessage());
         }
 
         User user = userService.findById(authUser.getId());
 
+        // 댓글 작성자와 현재 로그인한 사용자가 일치하는지 검증
         if (!comment.getWriter().getId().equals(user.getId())) {
             throw new CustomException(UNAUTHORIZED_COMMENT_ACCESS);
         }

--- a/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
@@ -10,7 +10,6 @@ import com.example.workoutmate.domain.comment.repository.CommentRepository;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.service.UserService;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
-import com.example.workoutmate.global.enums.CustomErrorCode;
 import com.example.workoutmate.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,8 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.example.workoutmate.global.enums.CustomErrorCode.COMMENT_NOT_IN_BOARD;
-import static com.example.workoutmate.global.enums.CustomErrorCode.UNAUTHORIZED_COMMENT_ACCESS;
+import static com.example.workoutmate.global.enums.CustomErrorCode.*;
 
 
 @Service
@@ -60,7 +58,7 @@ public class CommentService {
 
         // 해당 댓글이 요청받은 board에 속한 댓글인지 검증
         if (!comment.getBoard().getId().equals(board.getId())){
-            throw new CustomException(COMMENT_NOT_IN_BOARD, COMMENT_NOT_IN_BOARD.getMessage());
+            throw new CustomException(COMMENT_NOT_IN_BOARD);
         }
 
         User user = userService.findById(authUser.getId());
@@ -79,6 +77,6 @@ public class CommentService {
 
     public Comment findById(Long commentId){
         return commentRepository.findById(commentId)
-                .orElseThrow(() -> new CustomException(CustomErrorCode.COMMENT_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
@@ -10,11 +10,16 @@ import com.example.workoutmate.domain.comment.repository.CommentRepository;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.service.UserService;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
+import com.example.workoutmate.global.enums.CustomErrorCode;
+import com.example.workoutmate.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.example.workoutmate.global.enums.CustomErrorCode.COMMENT_NOT_IN_BOARD;
+import static com.example.workoutmate.global.enums.CustomErrorCode.UNAUTHORIZED_COMMENT_ACCESS;
 
 
 @Service
@@ -46,5 +51,32 @@ public class CommentService {
                 .stream().map(CommentMapper::data).toList();
 
         return comments;
+    }
+
+    @Transactional
+    public CommentResponseDto updateComment(Long boardId, Long commentId, CommentRequestDto requestDto, CustomUserPrincipal authUser) {
+        Board board = boardService.getBoardById(boardId);
+        Comment comment = findById(commentId);
+
+        if (!comment.getBoard().getId().equals(board.getId())){
+            throw new CustomException(COMMENT_NOT_IN_BOARD, COMMENT_NOT_IN_BOARD.getMessage());
+        }
+
+        User user = userService.findById(authUser.getId());
+
+        if (!comment.getWriter().getId().equals(user.getId())) {
+            throw new CustomException(UNAUTHORIZED_COMMENT_ACCESS);
+        }
+
+        comment.updateComment(requestDto.getContent());
+
+        commentRepository.flush();
+
+        return CommentMapper.data(comment);
+    }
+
+    public Comment findById(Long commentId){
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -23,8 +23,15 @@ public enum CustomErrorCode {
     // follow
     CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 팔로워 할 수 없습니다."),
     ALLREADY_FOLLOWING(HttpStatus.CONFLICT, "이미 팔로워 중입니다."),
-    NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "팔로우 중이지 않은 사용자입니다.")
-    ;
+    NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "팔로우 중이지 않은 사용자입니다."),
+
+
+    // Board
+
+    // Comment
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_IN_BOARD(HttpStatus.BAD_REQUEST, "댓글이 해당 게시물에 속하지 않습니다."),
+    UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "본인의 댓글만 수정 또는 삭제할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -25,9 +25,6 @@ public enum CustomErrorCode {
     ALLREADY_FOLLOWING(HttpStatus.CONFLICT, "이미 팔로워 중입니다."),
     NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "팔로우 중이지 않은 사용자입니다."),
 
-
-    // Board
-
     // Comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
     COMMENT_NOT_IN_BOARD(HttpStatus.BAD_REQUEST, "댓글이 해당 게시물에 속하지 않습니다."),


### PR DESCRIPTION
## 📌 개요
댓글 수정 AP 구현 

## ✅ 작업 사항
- [ ] 해당 댓글이 요청받은 board에 속한 댓글인지 검증
- [ ] 댓글 작성자와 현재 로그인한 사용자가 일치하는지 검증
- [ ] 댓글 수정 후 수정시간 즉시 반영 위해 flush() 적용

## 🔍 리뷰 요청 포인트


## 💬 기타 사항


---