### PR TITLE
Refactor/comment - 댓글 페이징 처리 

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/controller/CommentController.java
@@ -7,6 +7,10 @@ import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.example.workoutmate.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,10 +38,12 @@ public class CommentController {
     }
 
     @GetMapping("/boards/{boardId}/comments")
-    public ResponseEntity<ApiResponse<List<CommentResponseDto>>> getComment(
-            @PathVariable Long boardId
-    ){
-        List<CommentResponseDto> responseDto = commentService.getComment(boardId);
+    public ResponseEntity<ApiResponse<Page<CommentResponseDto>>> getComment(
+            @PathVariable Long boardId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            ){
+
+        Page<CommentResponseDto> responseDto = commentService.getComment(boardId, pageable);
 
         return ApiResponse.success(HttpStatus.OK, "댓글 조회에 성공하였습니다.", responseDto);
     }

--- a/src/main/java/com/example/workoutmate/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/repository/CommentRepository.java
@@ -1,15 +1,16 @@
 package com.example.workoutmate.domain.comment.repository;
 
 import com.example.workoutmate.domain.comment.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByBoardId(Long boardId);
+    Page<Comment> findAllByBoardId(Long boardId, Pageable pageable);
 
     Optional<Comment> findById(Long commentId);
 }

--- a/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
@@ -12,10 +12,10 @@ import com.example.workoutmate.domain.user.service.UserService;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.example.workoutmate.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static com.example.workoutmate.global.enums.CustomErrorCode.*;
 
@@ -42,13 +42,12 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<CommentResponseDto> getComment(Long boardId) {
+    public Page<CommentResponseDto> getComment(Long boardId, Pageable pageable) {
 
         // 레포지토리에서 게시글 ID로 댓글 목록 조회 후, DTO로 변환
-        List<CommentResponseDto> comments = commentRepository.findAllByBoardId(boardId)
-                .stream().map(CommentMapper::data).toList();
+        Page<Comment> comments = commentRepository.findAllByBoardId(boardId, pageable);
 
-        return comments;
+        return comments.map(CommentMapper::data);
     }
 
     @Transactional

--- a/src/main/java/com/example/workoutmate/global/config/PageConfig.java
+++ b/src/main/java/com/example/workoutmate/global/config/PageConfig.java
@@ -1,0 +1,12 @@
+package com.example.workoutmate.global.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class PageConfig {
+}

--- a/src/main/java/com/example/workoutmate/global/config/PageConfig.java
+++ b/src/main/java/com/example/workoutmate/global/config/PageConfig.java
@@ -6,6 +6,8 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
+// 페이징 응답(Page 객체)을 JSON으로 직렬화할 때,
+// 안정적인 구조(VIA_DTO)로 반환되도록 설정하는 Config 클래스
 @Configuration
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class PageConfig {


### PR DESCRIPTION
## 📌 개요
페이징 처리로 변경

## ✅ 작업 사항
- [x] @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO) 설정을 추가하여 Page 객체의 JSON 직렬화 구조 표준화
- [ ] PageConfig 설정 클래스 신규 생성
- [ ] 게시글, 댓글 등 목록 조회 API에 동일하게 페이징 구조 적용
 
## 🔍 리뷰 요청 포인트

## 💬 기타 사항
@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO) 설정 없이 JPA에서 제공해주는 Pageable로만 적용을 했을 때는 

<img width="2123" height="107" alt="스크린샷 2025-07-23 오전 10 59 54" src="https://github.com/user-attachments/assets/fba00602-025c-4132-be2d-ac49ce5dfe1a" />

이러한 경고 메세지가 떠서 콘솔에서 요구한 방식대로 구현을 하였습니다

@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO) 옵션을 설정하여  
응답 구조의 안정성을 확보하였습니다

## 번역 
PageImpl 인스턴스를 그대로 직렬화(serialize)하는 것은 지원되지 않으며, 그 결과로 만들어지는 JSON 구조의 안정성이 보장되지 않습니다!
안정적인 JSON 구조를 원한다면, Spring Data의 PagedModel을 사용하거나
@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO) 어노테이션을 전역적으로 적용하세요.
또는 공식 문서에 설명된 대로 Spring HATEOAS와 Spring Data의 PagedResourcesAssembler를 사용하세요.
(참고: https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.pageables)