### PR TITLE
feat(Zzim): 찜 삭제(해제) API 기능 구현

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/zzim/controller/ZzimController.java
+++ b/src/main/java/com/example/workoutmate/domain/zzim/controller/ZzimController.java
@@ -81,4 +81,15 @@ public class ZzimController {
         return ApiResponse.success(HttpStatus.OK, "유저의 찜 여부 조회 성공", responseDto);
     }
 
+    @DeleteMapping("/zzims/{zzimId}")
+    public ResponseEntity<ApiResponse<Void>> deleteZzim(
+            @PathVariable Long zzimId,
+            @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal
+    ) {
+        Long userId = customUserPrincipal.getId();
+        zzimService.deleteZzim(zzimId, userId);
+
+        return ApiResponse.success(HttpStatus.OK, "게시글 찜이 삭제되었습니다.", null);
+    }
+
 }

--- a/src/main/java/com/example/workoutmate/domain/zzim/service/ZzimService.java
+++ b/src/main/java/com/example/workoutmate/domain/zzim/service/ZzimService.java
@@ -108,5 +108,16 @@ public class ZzimService {
         }
     }
 
+    @Transactional
+    public void deleteZzim(Long zzimId, Long userId) {
 
+        Zzim zzim = zzimRepository.findById(zzimId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.ZZIM_NOT_FOUND));
+
+        if (!zzim.getUser().getId().equals(userId)) {
+            throw  new CustomException(CustomErrorCode.FORBIDDEN_ZZIM_ACCESS);
+        }
+
+        zzimRepository.delete(zzim);
+    }
 }

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -45,6 +45,8 @@ public enum CustomErrorCode {
     // Zzim
     ALREADY_ZZIM(HttpStatus.CONFLICT, "이미 찜한 게시글입니다."),
     CANNOT_ZZIM_OWN_BOARD(HttpStatus.BAD_REQUEST, "본인이 작성한 게시글은 찜할 수 없습니다."),
+    ZZIM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 찜 정보를 찾을 수 없습니다."),
+    FORBIDDEN_ZZIM_ACCESS(HttpStatus.FORBIDDEN, "해당 찜에 대한 권한이 없습니다."),
 
     // participation
     DUPLICATE_APPLICATION(HttpStatus.CONFLICT, "이미 신청한 결과가 있습니다."),


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 왜 수정했는지 설명해주세요. -->
찜 조회 API 기능을 구현하였습니다.
@DeleteMapping을 통해 찜데이터를 하드 딜리트로 삭제하는 기능을 구현하였습니다. 찜 userID와 본인 식별자를 비교하여 본인만 찜 삭제가 가능하도록 구현하였습니다.
삭제는 HardDelete로 구현하였습니다.

## PR 유형
어떤 변경 사항이 있나요?
ZzimController와 ZzimService에서 해당 기능을 구현하였습니다.
ZzimRepository를 수정하였습니다.

- [x] 게시글 찜 삭제 기능 구현


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 코드에 오류가 없는지 확인해주세요.
- [x] 코드의 작성 방식과 흐름이 규칙과 맞는지 확인해주세요.

참고자료
...