### PR TITLE
Feature(Board) 운동 종목 전체 조회 API 구현, 게시글 필터링 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/workoutmate/domain/board/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.example.workoutmate.domain.board.controller;
 
+import com.example.workoutmate.domain.board.dto.BoardFilterRequestDto;
 import com.example.workoutmate.domain.board.dto.BoardRequestDto;
 import com.example.workoutmate.domain.board.dto.BoardResponseDto;
 import com.example.workoutmate.domain.board.dto.BoardSportTypeResponseDto;
@@ -130,4 +131,18 @@ public class BoardController {
 
         return ApiResponse.success(HttpStatus.OK, "운동 종목 카테고리 전체 조회가 완료되었습니다.", responseDto);
     }
+
+    // 전체 조회 기능 통합
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<Page<BoardResponseDto>>> filterBoards(
+            @ModelAttribute BoardFilterRequestDto filterRequestDto,
+            @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal,
+            @PageableDefault(size = 10, sort = "modifiedAt", direction = Sort.Direction.DESC) Pageable pageable
+            ) {
+        Long userId = customUserPrincipal.getId();
+        Page<BoardResponseDto> result = boardService.searchBoards(userId, filterRequestDto, pageable);
+
+        return ApiResponse.success(HttpStatus.OK, "게시글 필터 조회 성공", result);
+    }
+
 }

--- a/src/main/java/com/example/workoutmate/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/workoutmate/domain/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.example.workoutmate.domain.board.controller;
 
 import com.example.workoutmate.domain.board.dto.BoardRequestDto;
 import com.example.workoutmate.domain.board.dto.BoardResponseDto;
+import com.example.workoutmate.domain.board.dto.BoardSportTypeResponseDto;
 import com.example.workoutmate.domain.board.entity.SportType;
 import com.example.workoutmate.domain.board.service.BoardService;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
@@ -119,5 +120,14 @@ public class BoardController {
         boardService.deleteBoard(boardId, userId);
 
         return ApiResponse.success(HttpStatus.OK, "게시글이 성공적으로 삭제되었습니다.", null);
+    }
+
+    // 운동 종목 카테고리 항목 조회
+    @GetMapping("/sportType")
+    public ResponseEntity<ApiResponse<BoardSportTypeResponseDto>> getAllSportTypes() {
+
+        BoardSportTypeResponseDto responseDto = boardService.getAllSportTypes();
+
+        return ApiResponse.success(HttpStatus.OK, "운동 종목 카테고리 전체 조회가 완료되었습니다.", responseDto);
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/board/dto/BoardFilterRequestDto.java
+++ b/src/main/java/com/example/workoutmate/domain/board/dto/BoardFilterRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.workoutmate.domain.board.dto;
+
+import com.example.workoutmate.domain.board.entity.SportType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BoardFilterRequestDto {
+
+    private Boolean onlyMyPosts;
+    private Boolean onlyFollowing;
+    private SportType sportType;
+    private Boolean onlyZzimmed;
+}

--- a/src/main/java/com/example/workoutmate/domain/board/dto/BoardSportTypeResponseDto.java
+++ b/src/main/java/com/example/workoutmate/domain/board/dto/BoardSportTypeResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.workoutmate.domain.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BoardSportTypeResponseDto {
+
+    private List<String> sportTypes;
+}

--- a/src/main/java/com/example/workoutmate/domain/board/repository/BoardQueryRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/board/repository/BoardQueryRepository.java
@@ -1,0 +1,10 @@
+package com.example.workoutmate.domain.board.repository;
+
+import com.example.workoutmate.domain.board.dto.BoardFilterRequestDto;
+import com.example.workoutmate.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardQueryRepository {
+    Page<Board> searchWithFilters(Long userId, BoardFilterRequestDto boardFilterRequestDto, Pageable pageable);
+}

--- a/src/main/java/com/example/workoutmate/domain/board/repository/BoardQueryRepositoryImpl.java
+++ b/src/main/java/com/example/workoutmate/domain/board/repository/BoardQueryRepositoryImpl.java
@@ -8,8 +8,6 @@ import com.example.workoutmate.domain.follow.entity.QFollow;
 import com.example.workoutmate.domain.user.entity.QUser;
 import com.example.workoutmate.domain.zzim.entity.QZzim;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Objects;
 
 @Repository
 @RequiredArgsConstructor
@@ -55,6 +54,9 @@ public class BoardQueryRepositoryImpl implements BoardQueryRepository {
                 .from(board)
                 .where(condition)
                 .fetchOne();
+
+        // total 값이 null일 경우 NullException을 방지하기 위해 0으로 변환 과정
+        total = Objects.requireNonNullElse(total, 0L);
 
         return new PageImpl<>(content, pageable, total);
     }

--- a/src/main/java/com/example/workoutmate/domain/board/repository/BoardQueryRepositoryImpl.java
+++ b/src/main/java/com/example/workoutmate/domain/board/repository/BoardQueryRepositoryImpl.java
@@ -1,0 +1,103 @@
+package com.example.workoutmate.domain.board.repository;
+
+import com.example.workoutmate.domain.board.dto.BoardFilterRequestDto;
+import com.example.workoutmate.domain.board.entity.Board;
+import com.example.workoutmate.domain.board.entity.QBoard;
+import com.example.workoutmate.domain.board.entity.SportType;
+import com.example.workoutmate.domain.follow.entity.QFollow;
+import com.example.workoutmate.domain.user.entity.QUser;
+import com.example.workoutmate.domain.zzim.entity.QZzim;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardQueryRepositoryImpl implements BoardQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Board> searchWithFilters(Long userId, BoardFilterRequestDto filter, Pageable pageable) {
+
+        QBoard board = QBoard.board;
+        QUser writer = QUser.user;
+        QFollow follow = QFollow.follow;
+        QZzim zzim = QZzim.zzim;
+
+        JPQLQuery<Board> query = queryFactory
+                .selectFrom(board)
+                .leftJoin(board.writer, writer).fetchJoin()
+                .where(
+                        board.isDeleted.eq(false),
+                        eqSportType(filter.getSportType()),
+                        eqMyPosts(userId, filter.getOnlyMyPosts()),
+                        eqFollowing(userId, filter.getOnlyFollowing()),
+                        eqZzimmed(userId, filter.getOnlyZzimmed())
+                )
+                .distinct();
+
+        long total = query.fetch().size();
+
+        List<Board> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(board.modifiedAt.desc())
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression eqSportType(SportType sportType) {
+        return sportType != null ? QBoard.board.sportType.eq(sportType) : null;
+    }
+
+    private BooleanExpression eqMyPosts(Long userId, Boolean onlyMyPosts) {
+        return onlyMyPosts != null && onlyMyPosts ? QBoard.board.writer.id.eq(userId) : null;
+    }
+
+    private BooleanExpression eqFollowing(Long userId, Boolean onlyFollowing) {
+        if (onlyFollowing != null && onlyFollowing) {
+            QFollow follow = QFollow.follow;
+            List<Long> followingIds = queryFactory
+                    .select(follow.following.id)
+                    .from(follow)
+                    .where(follow.follower.id.eq(userId))
+                    .fetch();
+
+            if (followingIds.isEmpty()) {
+                return QBoard.board.id.isNull(); // 결과가 없도록
+            }
+
+            return QBoard.board.writer.id.in(followingIds);
+        }
+        return null;
+    }
+
+    private BooleanExpression eqZzimmed(Long userId, Boolean onlyZzimmed) {
+        if (onlyZzimmed != null && onlyZzimmed) {
+            QZzim zzim = QZzim.zzim;
+
+            List<Long> boardIds = queryFactory
+                    .select(zzim.board.id)
+                    .from(zzim)
+                    .where(zzim.user.id.eq(userId))
+                    .fetch();
+
+            if (boardIds.isEmpty()) {
+                return QBoard.board.id.isNull();
+            }
+
+            return QBoard.board.id.in(boardIds);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/workoutmate/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/board/repository/BoardRepository.java
@@ -51,4 +51,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT b FROM Board b WHERE b.id = :id")
     Optional<Board> findByIdWithPessimisticLock(@Param("id") Long id);
 
+
+
 }

--- a/src/main/java/com/example/workoutmate/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/workoutmate/domain/board/service/BoardService.java
@@ -1,11 +1,13 @@
 package com.example.workoutmate.domain.board.service;
 
+import com.example.workoutmate.domain.board.dto.BoardFilterRequestDto;
 import com.example.workoutmate.domain.board.dto.BoardRequestDto;
 import com.example.workoutmate.domain.board.dto.BoardResponseDto;
 import com.example.workoutmate.domain.board.dto.BoardSportTypeResponseDto;
 import com.example.workoutmate.domain.board.entity.Board;
 import com.example.workoutmate.domain.board.entity.BoardMapper;
 import com.example.workoutmate.domain.board.entity.SportType;
+import com.example.workoutmate.domain.board.repository.BoardQueryRepository;
 import com.example.workoutmate.domain.board.repository.BoardRepository;
 import com.example.workoutmate.domain.follow.service.FollowService;
 import com.example.workoutmate.domain.user.entity.User;
@@ -30,6 +32,7 @@ import java.util.stream.Collectors;
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final BoardQueryRepository boardQueryRepository;
     private final BoardSearchService boardSearchService;
     private final UserService userService;
     private final FollowService followService;
@@ -157,6 +160,13 @@ public class BoardService {
                 .collect(Collectors.toList());
 
         return new BoardSportTypeResponseDto(sportTypes);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BoardResponseDto> searchBoards(Long userId, BoardFilterRequestDto filterRequestDto, Pageable pageable) {
+        Page<Board> boardPage = boardQueryRepository.searchWithFilters(userId, filterRequestDto, pageable);
+
+        return boardPage.map(BoardMapper::boardToBoardResponse);
     }
 
 }

--- a/src/main/java/com/example/workoutmate/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/workoutmate/domain/board/service/BoardService.java
@@ -2,6 +2,7 @@ package com.example.workoutmate.domain.board.service;
 
 import com.example.workoutmate.domain.board.dto.BoardRequestDto;
 import com.example.workoutmate.domain.board.dto.BoardResponseDto;
+import com.example.workoutmate.domain.board.dto.BoardSportTypeResponseDto;
 import com.example.workoutmate.domain.board.entity.Board;
 import com.example.workoutmate.domain.board.entity.BoardMapper;
 import com.example.workoutmate.domain.board.entity.SportType;
@@ -20,7 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -143,6 +146,17 @@ public class BoardService {
     @Transactional(readOnly = true)
     public Board findByIdWithPessimisticLock(Long id) {
         return boardRepository.findByIdWithPessimisticLock(id).orElseThrow(() -> new CustomException(CustomErrorCode.BOARD_NOT_FOUND));
+    }
+
+    // 운동 종목 카테고리 항목 조회
+    @Transactional(readOnly = true)
+    public BoardSportTypeResponseDto getAllSportTypes() {
+
+        List<String> sportTypes = Arrays.stream(SportType.values())
+                .map(Enum::name) // "RUNNING", "FOOTBALL",...
+                .collect(Collectors.toList());
+
+        return new BoardSportTypeResponseDto(sportTypes);
     }
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 왜 수정했는지 설명해주세요. -->
운동 종목 전체 조회하는 API 기능을 구현하였습니다.
게시글 필터링 조회 API 기능도 구현하였습니다.
기존에 각각 API로 분리하여 구현했던 게시글 조회기능을 게시글 전체 조회시 QueryDsl을 사용하여 필터링해서 게시글을 조회할 수 있도록 게시글 필터링 조회 API 기능으로 구현하였습니다.
게시글 필터링 조회기능을 통해, 게시글 전체조회, 내가 쓴 게시글 전체조회, 내가 팔로잉한 유저 게시글 전체조회, 내가 찜한 게시글 전체조회, 특정 운동 게시글 전체조회 기능이 하나의 api에서 필터링을 통해 조회가 가능하도록 구현하였습니다.

## PR 유형
어떤 변경 사항이 있나요?
BoardController와 BoardService에서 해당 기능을 구현하였습니다.
BoardQueryRepository를 생성하여 필터링 기능을 위한 쿼리를 구현하였습니다.

- [x] 운동 종목 전체 조회 기능 구현
- [x] 게시글 필터링 조회 기능 구현


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 코드에 오류가 없는지 확인해주세요.
- [x] 코드의 작성 방식과 흐름이 규칙과 맞는지 확인해주세요.

참고자료
...