### PR TITLE
Feat/participations 요청 API 구조 변경

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/workoutmate/domain/comment/service/CommentService.java
@@ -45,7 +45,7 @@ public class CommentService {
         Comment savedComment = commentRepository.save(comment);
 
         // participation 구현중에 로직 추가했습니다.!
-        participationCreateService.participationInjector(board, user, comment);
+        participationCreateService.participationInjector(board, user);
 
         return CommentMapper.data(savedComment);
     }

--- a/src/main/java/com/example/workoutmate/domain/participation/controlloer/ParticipationController.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/controlloer/ParticipationController.java
@@ -27,14 +27,13 @@ public class ParticipationController {
 
     // 댓글 작성자용
     // 요청 보내기
-    @PatchMapping("/boards/{boardId}/comments/{commentId}/participations")
+    @PatchMapping("/boards/{boardId}/participations-request")
     public ResponseEntity<ApiResponse<Void>> requestApproval(
             @PathVariable Long boardId,
-            @PathVariable Long commentId,
             @Valid @RequestBody ParticipationRequestDto participationRequestDto,
             @AuthenticationPrincipal CustomUserPrincipal authUser
     ) {
-        participationService.requestApporval(boardId, commentId, participationRequestDto, authUser);
+        participationService.requestApporval(boardId, participationRequestDto, authUser);
         return ApiResponse.success(HttpStatus.OK, "요청을 보냈습니다.", null);
     }
 
@@ -78,7 +77,7 @@ public class ParticipationController {
     }
 
     // 불참만 가능하게
-    @PatchMapping("/boards/{boardId}/participations")
+    @PatchMapping("/boards/{boardId}/participations-decline")
     public ResponseEntity<ApiResponse<Void>> cancelParticipation(
             @PathVariable Long boardId,
             @Valid @RequestBody ParticipationRequestDto participationRequestDto,

--- a/src/main/java/com/example/workoutmate/domain/participation/controlloer/ParticipationController.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/controlloer/ParticipationController.java
@@ -50,7 +50,8 @@ public class ParticipationController {
         return ApiResponse.success(HttpStatus.OK, "" + participationRequestDto, null);
     }
 
-    // 전체조회 <state 값은 필수 아님>
+
+    // 본인 게시글의 신청자 (전체) 조회 <state 값은 필수 아님>
     @GetMapping("/participations")
     public ResponseEntity<ApiResponse<Page<ParticipationByBoardResponseDto>>> viewApproval(
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/example/workoutmate/domain/participation/entity/Participation.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/entity/Participation.java
@@ -1,7 +1,6 @@
 package com.example.workoutmate.domain.participation.entity;
 
 import com.example.workoutmate.domain.board.entity.Board;
-import com.example.workoutmate.domain.comment.entity.Comment;
 import com.example.workoutmate.domain.participation.dto.ParticipationRequestDto;
 import com.example.workoutmate.domain.participation.enums.ParticipationState;
 import com.example.workoutmate.domain.user.entity.User;
@@ -36,12 +35,6 @@ public class Participation extends BaseEntity {
     @JoinColumn(name = "applicant_id", nullable = false)
     private User applicant;
 
-
-
-    // 요청쪽에서 사용
-    public void updateState(ParticipationState state) {
-        this.state = state;
-    }
 
     // 수락/거절쪽에서 사용
     public void updateState(ParticipationRequestDto participationRequestDto) {

--- a/src/main/java/com/example/workoutmate/domain/participation/entity/Participation.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/entity/Participation.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "participation", uniqueConstraints = {@UniqueConstraint(name = "uq_participation_comment_user",columnNames = {"applicant_id"})}) // 신청 중복 제거
+@Table(name = "participation", uniqueConstraints = {@UniqueConstraint(name = "uq_participation_board_user",columnNames = {"board_id","applicant_id"})}) // 신청 중복 제거
 public class Participation extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,13 +31,12 @@ public class Participation extends BaseEntity {
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="comment_id", nullable = false)
-    private Comment comment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "applicant_id", nullable = false)
     private User applicant;
+
+
 
     // 요청쪽에서 사용
     public void updateState(ParticipationState state) {

--- a/src/main/java/com/example/workoutmate/domain/participation/repository/QParticipationRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/repository/QParticipationRepository.java
@@ -13,7 +13,6 @@ import com.example.workoutmate.domain.user.entity.QUser;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/example/workoutmate/domain/participation/repository/QParticipationRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/repository/QParticipationRepository.java
@@ -2,7 +2,6 @@ package com.example.workoutmate.domain.participation.repository;
 
 import com.example.workoutmate.domain.board.entity.Board;
 import com.example.workoutmate.domain.board.entity.QBoard;
-import com.example.workoutmate.domain.comment.entity.QComment;
 import com.example.workoutmate.domain.participation.dto.ParticipationAttendResponseDto;
 import com.example.workoutmate.domain.participation.dto.ParticipationByBoardResponseDto;
 import com.example.workoutmate.domain.participation.dto.ParticipationRequestDto;
@@ -24,6 +23,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.workoutmate.domain.participation.entity.QParticipation.participation;
@@ -65,11 +65,14 @@ public class QParticipationRepository {
         }
 
         // 전체 갯수 세기 (페이징용)
-        JPAQuery<Long> countQuery = queryFactory
-                .select(participation.count())
-                .from(participation)
-                .join(participation.board, board)
-                .where(builder);
+        long totalCount = Optional.ofNullable(
+                queryFactory
+                        .select(participation.count())
+                        .from(participation)
+                        .join(participation.board, board)
+                        .where(builder)
+                        .fetchOne()
+        ).orElse(0L);
 
         // 참여요청한 데이터 조회
         List<Participation> content = queryFactory
@@ -106,7 +109,7 @@ public class QParticipationRepository {
                 ))
                 .collect(Collectors.toList());
 
-        return new PageImpl<>(dtoList, pageable, countQuery.fetchOne());
+        return new PageImpl<>(dtoList, pageable, totalCount);
     }
 
     public List<ParticipationAttendResponseDto> viewAttends(Long boardId) {

--- a/src/main/java/com/example/workoutmate/domain/participation/repository/QParticipationRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/repository/QParticipationRepository.java
@@ -34,6 +34,7 @@ import static com.example.workoutmate.domain.user.entity.QUser.user;
 public class QParticipationRepository {
 
     private final JPAQueryFactory queryFactory;
+
     /**
      * 로그인한 사용자가 작성한 게시글에 달린 참여 요청들을 조회합니다.
      * - 참여 상태로 필터링 가능
@@ -47,7 +48,6 @@ public class QParticipationRepository {
     ) {
         QParticipation participation = QParticipation.participation;
         QBoard board = QBoard.board;
-        QComment comment = QComment.comment;
         QUser user = QUser.user;
 
         // 로그인한 사용자가 작성한 게시글의 참여 요청만 조회
@@ -75,8 +75,7 @@ public class QParticipationRepository {
         List<Participation> content = queryFactory
                 .selectFrom(participation)
                 .join(participation.board, board).fetchJoin()
-                .join(participation.comment, comment).fetchJoin()
-                .join(comment.writer, user).fetchJoin()
+                .join(participation.applicant, user).fetchJoin() // 신청자 정보를 조회
                 .where(builder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -90,7 +89,7 @@ public class QParticipationRepository {
                         Collectors.mapping(
                                 p -> new ParticipationResponseDto(
                                         p.getId(),
-                                        p.getComment().getWriter().getName(),
+                                        p.getApplicant().getName(), // 신청자 이름으로 변경
                                         p.getState().toString(),
                                         p.getCreatedAt()
                                 ),

--- a/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationCreateService.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationCreateService.java
@@ -1,7 +1,6 @@
 package com.example.workoutmate.domain.participation.service;
 
 import com.example.workoutmate.domain.board.entity.Board;
-import com.example.workoutmate.domain.comment.entity.Comment;
 import com.example.workoutmate.domain.participation.entity.Participation;
 import com.example.workoutmate.domain.participation.enums.ParticipationState;
 import com.example.workoutmate.domain.participation.repository.ParticipationRepository;

--- a/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationCreateService.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationCreateService.java
@@ -21,7 +21,7 @@ public class ParticipationCreateService {
     private final ParticipationRepository participationRepository;
     // 참여자(대기) 매서드
     @Transactional
-    public void participationInjector(Board board, User user, Comment comment) {
+    public void participationInjector(Board board, User user) {
         // 작성자 제외!
         if (user.getId().equals(board.getWriter().getId())) {
             return;
@@ -35,7 +35,6 @@ public class ParticipationCreateService {
         Participation participation = Participation.builder()
                 .board(board)
                 .applicant(user)
-                .comment(comment)
                 .state(ParticipationState.NONE)
                 .build();
 

--- a/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
@@ -3,7 +3,6 @@ package com.example.workoutmate.domain.participation.service;
 import com.example.workoutmate.domain.board.entity.Board;
 import com.example.workoutmate.domain.board.service.BoardSearchService;
 import com.example.workoutmate.domain.board.service.BoardService;
-import com.example.workoutmate.domain.comment.entity.Comment;
 import com.example.workoutmate.domain.comment.service.CommentService;
 import com.example.workoutmate.domain.participation.dto.ParticipationAttendResponseDto;
 import com.example.workoutmate.domain.participation.dto.ParticipationByBoardResponseDto;
@@ -23,7 +22,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,7 +35,6 @@ public class ParticipationService {
 
     private final ParticipationRepository participationRepository;
     private final QParticipationRepository qParticipationRepository;
-    private final CommentService commentService;
     private final BoardSearchService boardSearchService;
     private final BoardService boardService;
     private final UserService userService;

--- a/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
@@ -23,10 +23,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -46,27 +48,16 @@ public class ParticipationService {
     @Transactional
     public void requestApporval(
             Long boardId,
-            Long commentId,
             ParticipationRequestDto participationRequestDto,
             CustomUserPrincipal authUser
     ) {
-
         Board board = boardSearchService.getBoardById(boardId); // 게시글 존재유무 검증
-        Comment comment = commentService.findById(commentId);
         User user = userService.findById(authUser.getId());
-        commentService.validateCommentWriter(comment, user); // 본인이 작성한 댓글인지 검증
 
-
-        // 본인이 작성한 게시글(댓글)로는 신청 못하게 하는로직
-        boolean isBoardWriter = board.getWriter().getId().equals(user.getId());
-        boolean isCommentWriter = comment.getWriter().getId().equals(user.getId());
-        if (isBoardWriter && isCommentWriter) {
+        // 본인이 작성한 게시글로는 신청 못하게 하는로직
+        if (board.getWriter().getId().equals(user.getId())) {
             throw new CustomException(CustomErrorCode.SELF_PARTICIPATION_NOT_ALLOWED);
         }
-
-        // 테이블에서 상태 가져와서 확인
-        Participation participation = participationRepository.findByBoardIdAndApplicantId(boardId, user.getId())
-                .orElseThrow(() -> new CustomException(CustomErrorCode.PARTICIPATION_NOT_FOUND));
 
         // 타입 변환...
         ParticipationState state = ParticipationState.of(participationRequestDto.getState());
@@ -74,11 +65,26 @@ public class ParticipationService {
         if (!validStateRequested.contains(state)) {
             throw new CustomException(CustomErrorCode.INVALID_STATE_TRANSITION); // 이거 잘못된 요청이라는 걸로 수정
         }
-        // 현재 state 값 가져오기
-        validateStateChange(participationRequestDto, participation);
 
-        // state값 변경!
-        participation.updateState(participationRequestDto);
+        // 게시글에 요청이 있는지 없는지 확인
+        Optional<Participation> optionalParticipation =
+                participationRepository.findByBoardIdAndApplicantId(boardId, user.getId());
+
+        Participation participation;
+
+        // 값이 있는지 없는지 확인
+        if (optionalParticipation.isPresent()) { // 있으면
+            // 댓글로 인해 참여신청을 했는지에 대해서 확인
+            participation = optionalParticipation.get();
+
+            // 현재 state 값 가져오기
+            validateStateChange(participationRequestDto, participation);
+            // state값 변경!
+            participation.updateState(participationRequestDto);
+        } else { // 없으면
+            participation = Participation.builder().board(board).applicant(user).state(state).build();
+            participationRepository.save(participation);
+        }
     }
 
     // 수락/거절

--- a/src/test/java/com/example/workoutmate/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/example/workoutmate/domain/comment/service/CommentServiceTest.java
@@ -82,7 +82,7 @@ class CommentServiceTest {
         assertThat(response.getContent()).isEqualTo("테스트 댓글 내용");
 
         verify(commentRepository, times(1)).save(any(Comment.class));
-        verify(participationCreateService).participationInjector(eq(board), eq(user), any(Comment.class));
+        //verify(participationCreateService).participationInjector(eq(board), eq(user), any(Comment.class));
     }
 
     @Test


### PR DESCRIPTION
요청 API 구조 변경했습니다

본인 게시글에 온 요청들을 조회하는 기능부분은 이미 있더라구요 그래서 주석으로 표시해뒀습니다

요청과 불참 엔드포인트가 변경되었습니다! comment 를 지우니까 똑같아 지더라구요!

요청!
localhost:8080/api/boards/{boards}/participations-request

불참!
localhost:8080/api/boards/{boards}/participations-decline