### PR TITLE
Feature(chatting): 채팅방 나가기, 채팅방 재입장 시 메시지 조회 기능 수정

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/chatting/repository/ChatRoomMemberRepositoryImpl.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/repository/ChatRoomMemberRepositoryImpl.java
@@ -43,7 +43,8 @@ public class ChatRoomMemberRepositoryImpl implements ChatRoomMemberRepositoryCus
                     JPAExpressions
                             .select(m.createdAt.max())
                             .from(m)
-                            .where(m.chatRoomId.eq(c.id))
+                            .where(m.chatRoomId.eq(c.id)
+                                    .and(m.createdAt.after(cm.joinedAt)))
                             .lt(cursor)
             );
         }
@@ -52,7 +53,8 @@ public class ChatRoomMemberRepositoryImpl implements ChatRoomMemberRepositoryCus
         var latestMessageSubquery = JPAExpressions
                 .select(m.createdAt.max())
                 .from(m)
-                .where(m.chatRoomId.eq(c.id));
+                .where(m.chatRoomId.eq(c.id)
+                        .and(m.createdAt.after(cm.joinedAt)));
 
         return queryFactory
                 .select(new QChatRoomResponseDto(

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChattingService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChattingService.java
@@ -160,6 +160,10 @@ public class ChattingService {
         ChatRoomMember member = chatRoomMemberRepository.findByUserIdAndChatRoomId(user.getId(), chatRoomId)
                 .orElseThrow(() -> new CustomException(CHATROOM_MEMBER_NOT_FOUND, "채팅방 멤버가 존재하지 않습니다."));
 
+        if (!member.isJoined()) {
+            throw new CustomException(ALREADY_LEFT_CHATROOM, ALREADY_LEFT_CHATROOM.getMessage());
+        }
+
         // 채팅방 퇴장
         member.leave();
 

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -56,6 +56,7 @@ public enum CustomErrorCode {
     EQUALS_SENDER_RECEIVER(HttpStatus.BAD_REQUEST, "본인과는 채팅방을 생성할 수 없습니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
     CHATROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 멤버가 존재하지 않습니다."),
+    ALREADY_LEFT_CHATROOM(HttpStatus.BAD_REQUEST, "이미 채팅방을 나간 유저입니다."),
 
 
     // Zzim


### PR DESCRIPTION
### **📌 개요**
채팅방 나가기, 채팅방 재입장 시 메시지 조회 기능 수정하였습니다.

### **✅ 작업 사항**
채팅방 나간 상태의 유저는 채팅방 나가기 불가하도록 추가 (ChattingService, CustomErrorCode)
채팅방 나간 유저가 재입장 시 재입장 시점부터 메시지 조회 가능하도록 추가 (ChatRoomMemberRepositoryImpl)

### **🔍 리뷰 요청 포인트**
### **💬 기타 사항**