### PR TITLE
Fix(Board) 게시글 삭제 API 수정

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/workoutmate/domain/board/service/BoardService.java
@@ -135,6 +135,11 @@ public class BoardService {
 
         validateBoardWriter(userId, board);
 
+        // 현재 모집된 인원이 있을경우 삭제 불가
+        if (board.getCurrentParticipants() > 0) {
+            throw new CustomException(CustomErrorCode.BOARD_HAS_PARTICIPANTS);
+        }
+
         board.delete();
     }
 
@@ -162,6 +167,7 @@ public class BoardService {
         return new BoardSportTypeResponseDto(sportTypes);
     }
 
+    // 게시글 통합 조회(필터링) 기능
     @Transactional(readOnly = true)
     public Page<BoardResponseDto> searchBoards(Long userId, BoardFilterRequestDto filterRequestDto, Pageable pageable) {
         Page<Board> boardPage = boardQueryRepository.searchWithFilters(userId, filterRequestDto, pageable);

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -42,6 +42,7 @@ public enum CustomErrorCode {
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
     UNAUTHORIZED_BOARD_ACCESS(HttpStatus.FORBIDDEN, "본인의 게시글만 수정 또는 삭제가 가능합니다."),
     INVALID_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "모집인원은 모집 확정 인원보다 커야합니다."),
+    BOARD_HAS_PARTICIPANTS(HttpStatus.BAD_REQUEST, "현재 참여자가 있어 게시글을 삭제할 수 없습니다."),
 
     // Comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 왜 수정했는지 설명해주세요. -->
게시글 삭제 api를 수정하였습니다.
기존에 게시글 작성자와 사용자가 일치하면 삭제가 가능했던 기능을 수정하였습니다.
수정 후에는 게시글에 참여인원이 0일 경우에만 삭제가 가능하도록 수정하였습니다.

## PR 유형
어떤 변경 사항이 있나요?
BoardController와 BoardService에서 해당 기능을 구현하였습니다.

- [x] 게시글 삭제 시 게시글 참여자 조회 후 0명일 경우만 삭제 가능


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [ ] 코드에 오류가 없는지 확인해주세요.
- [ ] 코드의 작성 방식과 흐름이 규칙과 맞는지 확인해주세요.

참고자료
...