### PR TITLE
Feat/participations 운동파티 다 차면 status 값 변경

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/board/entity/Board.java
+++ b/src/main/java/com/example/workoutmate/domain/board/entity/Board.java
@@ -102,4 +102,10 @@ public class Board extends BaseEntity {
             this.currentParticipants--;
         }
     }
+
+    public void changeStatus(Status status) {
+        if (this.status != status) {
+            this.status = status;
+        }
+    }
 }

--- a/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
@@ -109,12 +109,15 @@ public class ParticipationService {
         ParticipationState state = ParticipationState.of(participationRequestDto.getState());
 
         if (state == ParticipationState.ACCEPTED) {
-            board.increaseCurrentParticipants();
-            if (board.getStatus().equals(Status.OPEN)) {
-                board.changeStatus(Status.CLOSED);
+            if (board.getCurrentParticipants() < board.getMaxParticipants()) {
+                board.increaseCurrentParticipants();
+                if (board.getCurrentParticipants().equals(board.getMaxParticipants())) {
+                    board.changeStatus(Status.CLOSED);
+                }
+            } else {
+                throw new CustomException(CustomErrorCode.BOARD_FULL);
             }
         }
-
         participation.updateState(participationRequestDto);
     }
 

--- a/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
+++ b/src/main/java/com/example/workoutmate/domain/participation/service/ParticipationService.java
@@ -1,6 +1,7 @@
 package com.example.workoutmate.domain.participation.service;
 
 import com.example.workoutmate.domain.board.entity.Board;
+import com.example.workoutmate.domain.board.enums.Status;
 import com.example.workoutmate.domain.board.service.BoardSearchService;
 import com.example.workoutmate.domain.board.service.BoardService;
 import com.example.workoutmate.domain.comment.service.CommentService;
@@ -69,6 +70,10 @@ public class ParticipationService {
 
         Participation participation;
 
+        if (board.getStatus().equals(Status.CLOSED)) {
+            throw new CustomException(CustomErrorCode.BOARD_FULL);
+        }
+
         // 값이 있는지 없는지 확인
         if (optionalParticipation.isPresent()) { // 있으면
             // 댓글로 인해 참여신청을 했는지에 대해서 확인
@@ -105,6 +110,9 @@ public class ParticipationService {
 
         if (state == ParticipationState.ACCEPTED) {
             board.increaseCurrentParticipants();
+            if (board.getStatus().equals(Status.OPEN)) {
+                board.changeStatus(Status.CLOSED);
+            }
         }
 
         participation.updateState(participationRequestDto);
@@ -141,6 +149,9 @@ public class ParticipationService {
         // 불참으로 변경시 -1 하는 로직
         if (isChoosingToDecline && participation.getState() == ParticipationState.ACCEPTED) {
             board.decreaseCurrentParticipants();
+            if (board.getStatus().equals(Status.CLOSED)) {
+                board.changeStatus(Status.OPEN);
+            }
         }
 
         participation.updateState(participationRequestDto);


### PR DESCRIPTION
운동파티 다 차면 status 값 변경
1. 요청 보낼시 status가 닫혀있으면 요청 못보냄
2. 불참시 status 닫힌거를 오픈으로 변경
3. 수락시 인원 비교하고 가득차면 status 값  닫힘으로 변경