### PR TITLE
Feature(chatting): 웹소켓 연결 시 헤더로 jwt 토큰 전달 및 인증 처리

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/chatting/config/ChatAuthHandler.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/ChatAuthHandler.java
@@ -1,0 +1,62 @@
+package com.example.workoutmate.domain.chatting.config;
+
+import com.example.workoutmate.domain.user.enums.UserRole;
+import com.example.workoutmate.global.config.CustomUserPrincipal;
+import com.example.workoutmate.global.exception.CustomException;
+import com.example.workoutmate.global.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+
+import static com.example.workoutmate.global.enums.CustomErrorCode.TOKEN_NOT_FOUND;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatAuthHandler implements ChannelInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if(StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String jwtToken = accessor.getFirstNativeHeader("Authorization");
+            String token = jwtUtil.substringToken(jwtToken);
+
+            try {
+                Claims claims = jwtUtil.extractClaims(token);
+
+                if (claims == null) {
+                    throw new CustomException(TOKEN_NOT_FOUND, TOKEN_NOT_FOUND.getMessage());
+                }
+
+                Long userId = Long.valueOf(claims.getSubject());
+                String email = claims.get("email", String.class);
+                String role = claims.get("userRole", String.class);
+
+                CustomUserPrincipal userPrincipal = new CustomUserPrincipal(userId, email, UserRole.valueOf(role));
+
+                accessor.setUser(userPrincipal);
+                accessor.getSessionAttributes().put("user", userPrincipal);
+
+                return message;
+
+            } catch (Exception e) {
+                log.error("WebSocket Handler JWT 에러", e);
+                throw new CustomException(TOKEN_NOT_FOUND, TOKEN_NOT_FOUND.getMessage());
+            }
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/example/workoutmate/domain/chatting/config/WebSocketConfig.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/WebSocketConfig.java
@@ -2,6 +2,7 @@ package com.example.workoutmate.domain.chatting.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -11,6 +12,8 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final ChatAuthHandler chatAuthHandler;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -33,5 +36,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 // WebSocket을 지원하지 않는 브라우저를 위한 SockJS 지원 추가
                 .withSockJS()
         ;
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(chatAuthHandler);
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.example.workoutmate.domain.chatting.controller;
 
 import com.example.workoutmate.domain.chatting.dto.ChatDto;
 import com.example.workoutmate.domain.chatting.service.ChatMessageService;
+import com.example.workoutmate.global.config.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -18,8 +19,10 @@ public class ChatController {
     private final ChatMessageService chatMessageService;
 
     @MessageMapping("/chats/send-message")
-    public void sendMessage(@Payload ChatDto chat) {
-        ChatDto chatDto = chatMessageService.save(chat);
+    public void sendMessage(@Payload ChatDto chat,
+                            CustomUserPrincipal user) {
+
+        ChatDto chatDto = chatMessageService.save(chat, user.getEmail());
         template.convertAndSend("/sub/chat/mates/" + chat.getChatRoomId(), chatDto);
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -7,9 +7,11 @@ import com.example.workoutmate.domain.chatting.repository.ChatMessageRepository;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
@@ -18,8 +20,8 @@ public class ChatMessageService {
     private final UserService userService;
 
     @Transactional
-    public ChatDto save(ChatDto chatDto) {
-        User sender = userService.findById(chatDto.getSenderId());
+    public ChatDto save(ChatDto chatDto, String email) {
+        User sender = userService.findByEmail(email);
 
         ChatMessage chatMessage = ChattingMapper.toChatMessage(chatDto, sender);
 

--- a/src/main/java/com/example/workoutmate/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/user/repository/UserRepository.java
@@ -23,6 +23,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndIsDeletedFalseAndIsEmailVerifiedFalse(String email);
 
+    Optional<User> findByEmailAndIsDeletedFalseAndIsEmailVerifiedTrue(String email);
+
     @Query("SELECT u FROM User u WHERE u.isEmailVerified = false AND u.createdAt < :time")
     Page<User> findUnverifiedUsers(@Param("time")LocalDateTime time, Pageable pageable);
 }

--- a/src/main/java/com/example/workoutmate/domain/user/service/UserService.java
+++ b/src/main/java/com/example/workoutmate/domain/user/service/UserService.java
@@ -117,4 +117,9 @@ public class UserService {
         return userRepository.findByIdAndIsDeletedFalse(id).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND, USER_NOT_FOUND.getMessage()));
     }
+
+    public User findByEmail(String email) {
+        return userRepository.findByEmailAndIsDeletedFalseAndIsEmailVerifiedTrue(email).orElseThrow(
+                () -> new CustomException(USER_NOT_FOUND, USER_NOT_FOUND.getMessage()));
+    }
 }

--- a/src/main/java/com/example/workoutmate/global/config/CustomUserPrincipal.java
+++ b/src/main/java/com/example/workoutmate/global/config/CustomUserPrincipal.java
@@ -5,11 +5,12 @@ import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.security.Principal;
 import java.util.Collection;
 import java.util.List;
 
 @Getter
-public class CustomUserPrincipal implements UserDetails {
+public class CustomUserPrincipal implements UserDetails, Principal {
 
     private final Long id;
     private final String email;
@@ -33,6 +34,12 @@ public class CustomUserPrincipal implements UserDetails {
 
     @Override
     public String getUsername() {
+        return email;
+    }
+
+    // WebSocket에서 사용자 식별용
+    @Override
+    public String getName() {
         return email;
     }
 }

--- a/src/main/java/com/example/workoutmate/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/workoutmate/global/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -68,7 +69,9 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         // 허용할 출처(Origin)를 명시적으로 지정
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:63342"));
+        configuration.setAllowedOrigins(
+                List.of("http://localhost:63342", "https://jiangxy.github.io")
+        );
 
         // 허용할 HTTP 메서드 설정
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -1,6 +1,7 @@
 package com.example.workoutmate.global.enums;
 
 import lombok.Getter;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -57,7 +58,7 @@ public enum CustomErrorCode {
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
     CHATROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 멤버가 존재하지 않습니다."),
     ALREADY_LEFT_CHATROOM(HttpStatus.BAD_REQUEST, "이미 채팅방을 나간 유저입니다."),
-
+    TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "헤더에 JWT 토큰이 존재하지 않습니다."),
 
     // Zzim
     ALREADY_ZZIM(HttpStatus.CONFLICT, "이미 찜한 게시글입니다."),

--- a/src/main/resources/static/stomp-test.html
+++ b/src/main/resources/static/stomp-test.html
@@ -24,21 +24,27 @@
             const url = $('#websocketUrl').val();
             const token = $('#jwtToken').val();
 
-            if (!token) {
-                alert('JWT Token을 입력해주세요.');
-                return;
-            }
+            // if (!token) {
+            //     alert('JWT Token을 입력해주세요.');
+            //     return;
+            // }
 
             // STOMP 연결 시 헤더에 인증 정보 추가
             const connectHeaders = {
                 Authorization: `Bearer ${token}`
             };
 
-            const socket = new SockJS(url);
+            const urlWithToken = `${url}?token=${token}`;
+
+            const socket = new SockJS(urlWithToken);
+            // const socket = new WebSocket(url);
             stompClient = Stomp.over(socket);
 
             // 연결 성공 시 이전 메시지 불러오고, 구독 시작
-            stompClient.connect(connectHeaders, () => {
+            // stompClient.connect(connectHeaders, () => {
+            stompClient.connect({
+                Authorization: `Bearer ${token}`
+            }, () => {
                 console.log('connected!');
 
                 fetchOldMessages(chatRoomId); // 1. 이전 메시지 먼저 로딩


### PR DESCRIPTION
📌 개요
웹소켓 연결 시 헤더로 jwt 토큰 전달 및 인증 처리 구현

✅ 작업 사항
웹소켓 CONNECT 시 헤더로 jwt 토큰을 전달하면 ChatAuthHandler를 통해 jwt 토큰 인증 및 유저 정보를 저장,
이후 메시지 SEND 시 저장한 유저 정보를 통해 userId를 추출하여 메시지를 DB에 저장합니다.

🔍 리뷰 요청 포인트
기존 CustomUserPrincipal 클래스에 Principal 클래스를 상속 받았습니다.
이는 WebSocket에서 유저 정보를 받기 위해서는 Principal 클래스를 사용해야 하기 때문입니다.

💬 기타 사항
CONNECT 시 저장된 토큰은 재연결 하지 않는 이상 지속되기 때문에
토큰 만료 상황에서 보안을 유지하기 위한 메서드를 추후 추가 예정입니다.