### PR TITLE
Feature(chatting): 채팅 입장메시지, 퇴장메시지 구현, 메시지 발행 책임 분리

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
@@ -6,7 +6,6 @@ import com.example.workoutmate.global.config.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -15,14 +14,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 public class ChatController {
 
-    private final SimpMessageSendingOperations template;
     private final ChatMessageService chatMessageService;
 
     @MessageMapping("/chats/send-message")
     public void sendMessage(@Payload ChatDto chat,
                             CustomUserPrincipal user) {
 
-        ChatDto chatDto = chatMessageService.save(chat, user.getEmail());
-        template.convertAndSend("/sub/chat/mates/" + chat.getChatRoomId(), chatDto);
+        chatMessageService.save(chat, user.getEmail());
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/controller/ChattingController.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/controller/ChattingController.java
@@ -36,7 +36,7 @@ public class ChattingController {
      * @param authUser 로그인한 유저 정보
      * @return 채팅방 정보 (새 채팅방 or 기존 채팅방)
      */
-    @PostMapping("/chat_rooms/{userId}")
+    @PostMapping("/chat-rooms/{userId}")
     public ResponseEntity<ApiResponse<ChatRoomCreateResponseDto>> createChatRoom(
             @PathVariable Long userId,
             @AuthenticationPrincipal CustomUserPrincipal authUser) {
@@ -55,7 +55,7 @@ public class ChattingController {
      * @param size 한 페이지에 조회할 채팅방 개수
      * @return 조회된 내 채팅방 정보
      */
-    @GetMapping("/chat_rooms/me")
+    @GetMapping("/chat-rooms/me")
     public ResponseEntity<ApiResponse<List<ChatRoomResponseDto>>> getMyChatRooms(
             @AuthenticationPrincipal CustomUserPrincipal authUser,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursor,
@@ -76,7 +76,7 @@ public class ChattingController {
      * @param size 한 페이지에 조회할 메시지 개수
      * @return 조회된 채팅방 메시지 정보
      */
-    @GetMapping("/chat_rooms/message/{chatRoomId}")
+    @GetMapping("/chat-rooms/message/{chatRoomId}")
     public ResponseEntity<ApiResponse<List<ChatMessageResponseDto>>> getChatRoomMessage(
         @PathVariable Long chatRoomId,
         @AuthenticationPrincipal CustomUserPrincipal authUser,
@@ -95,7 +95,7 @@ public class ChattingController {
      * @param chatRoomId 채팅방 id
      * @param authUser 로그인한 유저 정보
      */
-    @DeleteMapping("/chat_rooms/{chatRoomId}/deletion")
+    @DeleteMapping("/chat-rooms/{chatRoomId}/deletion")
     public ResponseEntity<ApiResponse<Void>> leaveChatRoom(
             @PathVariable Long chatRoomId,
             @AuthenticationPrincipal CustomUserPrincipal authUser) {

--- a/src/main/java/com/example/workoutmate/domain/chatting/dto/ChatDto.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/dto/ChatDto.java
@@ -1,9 +1,9 @@
 package com.example.workoutmate.domain.chatting.dto;
 
+import com.example.workoutmate.domain.chatting.enums.MessageType;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -14,4 +14,17 @@ public class ChatDto {
     private String senderName;
     private String message;
     private String createdAt;
+    private MessageType type;
+
+    public void setTypeTalk() {
+        this.type = MessageType.TALK;
+    }
+
+    public void setTypeEnter() {
+        this.type = MessageType.ENTER;
+    }
+
+    public void setTypeLeave() {
+        this.type = MessageType.LEAVE;
+    }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/dto/ChatMessageResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.workoutmate.domain.chatting.dto;
 
+import com.example.workoutmate.domain.chatting.enums.MessageType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,4 +18,5 @@ public class ChatMessageResponseDto {
     private String senderName;
     private String message;
     private LocalDateTime createdAt;
+    private MessageType type;
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/entity/ChatMessage.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/entity/ChatMessage.java
@@ -1,11 +1,14 @@
 package com.example.workoutmate.domain.chatting.entity;
 
+import com.example.workoutmate.domain.chatting.enums.MessageType;
 import com.example.workoutmate.domain.user.entity.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -21,6 +24,7 @@ public class ChatMessage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     private Long chatRoomId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -29,5 +33,11 @@ public class ChatMessage {
 
     private String message;
 
+    @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private MessageType type;
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/entity/ChattingMapper.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/entity/ChattingMapper.java
@@ -16,6 +16,7 @@ public class ChattingMapper {
                 .sender(user)
                 .message(chatDto.getMessage())
                 .createdAt(LocalDateTime.now())
+                .type(chatDto.getType())
                 .build();
     }
 
@@ -49,6 +50,7 @@ public class ChattingMapper {
                 .senderName(chatMessage.getSender().getName())
                 .message(chatMessage.getMessage())
                 .createdAt(chatMessage.getCreatedAt().toString())
+                .type(chatMessage.getType())
                 .build();
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/entity/ChattingMapper.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/entity/ChattingMapper.java
@@ -3,11 +3,43 @@ package com.example.workoutmate.domain.chatting.entity;
 import com.example.workoutmate.domain.chatting.dto.ChatDto;
 import com.example.workoutmate.domain.chatting.dto.ChatMessageResponseDto;
 import com.example.workoutmate.domain.chatting.dto.ChatRoomCreateResponseDto;
+import com.example.workoutmate.domain.chatting.enums.MessageType;
 import com.example.workoutmate.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 
 public class ChattingMapper {
+
+    // Entity -> Entity
+    public static ChatMessage memberToStartMessage(ChatRoomMember chatRoomMember, User sender) {
+        return ChatMessage.builder()
+                .chatRoomId(chatRoomMember.getChatRoomId())
+                .sender(sender)
+                .message(sender.getName() + "님이 대화를 시작하였습니다.")
+                .createdAt(chatRoomMember.getJoinedAt())
+                .type(MessageType.ENTER)
+                .build();
+    }
+
+    public static ChatMessage memberToJoinMessage(ChatRoomMember chatRoomMember, User sender) {
+        return ChatMessage.builder()
+                .chatRoomId(chatRoomMember.getChatRoomId())
+                .sender(sender)
+                .message(sender.getName() + "님이 입장했습니다.")
+                .createdAt(chatRoomMember.getJoinedAt())
+                .type(MessageType.ENTER)
+                .build();
+    }
+
+    public static ChatMessage memberToLeaveMessage(ChatRoomMember chatRoomMember, User sender) {
+        return ChatMessage.builder()
+                .chatRoomId(chatRoomMember.getChatRoomId())
+                .sender(sender)
+                .message(sender.getName() + "님이 퇴장했습니다.")
+                .createdAt(chatRoomMember.getLeftAt())
+                .type(MessageType.LEAVE)
+                .build();
+    }
 
     // Dto -> Entity (ChatMessage)
     public static ChatMessage toChatMessage(ChatDto chatDto, User user) {

--- a/src/main/java/com/example/workoutmate/domain/chatting/entity/ChattingMapper.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/entity/ChattingMapper.java
@@ -39,6 +39,7 @@ public class ChattingMapper {
                 .senderName(chatMessage.getSender().getName())
                 .message(chatMessage.getMessage())
                 .createdAt(chatMessage.getCreatedAt())
+                .type(chatMessage.getType())
                 .build();
     }
 

--- a/src/main/java/com/example/workoutmate/domain/chatting/enums/MessageType.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/enums/MessageType.java
@@ -1,0 +1,7 @@
+package com.example.workoutmate.domain.chatting.enums;
+
+public enum MessageType {
+    ENTER,
+    LEAVE,
+    TALK
+}

--- a/src/main/java/com/example/workoutmate/domain/chatting/event/ChatPublisher.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/event/ChatPublisher.java
@@ -1,0 +1,20 @@
+package com.example.workoutmate.domain.chatting.event;
+
+import com.example.workoutmate.domain.chatting.dto.ChatDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+/**
+ * WebSocket 메시지 발행(Publishing)을 전담하는 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class ChatPublisher {
+
+    private final SimpMessageSendingOperations template;
+
+    public void sendMessage(Long chatRoomId, ChatDto message) {
+        template.convertAndSend("/sub/chat/mates/" + chatRoomId, message);
+    }
+}

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -3,6 +3,7 @@ package com.example.workoutmate.domain.chatting.service;
 import com.example.workoutmate.domain.chatting.dto.ChatDto;
 import com.example.workoutmate.domain.chatting.entity.ChatMessage;
 import com.example.workoutmate.domain.chatting.entity.ChattingMapper;
+import com.example.workoutmate.domain.chatting.event.ChatPublisher;
 import com.example.workoutmate.domain.chatting.repository.ChatMessageRepository;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.service.UserService;
@@ -16,9 +17,10 @@ public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final UserService userService;
+    private final ChatPublisher chatPublisher;
 
     @Transactional
-    public ChatDto save(ChatDto chatDto, String email) {
+    public void save(ChatDto chatDto, String email) {
         User sender = userService.findByEmail(email);
 
         chatDto.setTypeTalk();
@@ -26,6 +28,8 @@ public class ChatMessageService {
 
         chatMessageRepository.save(chatMessage);
 
-        return ChattingMapper.toChatDto(chatMessage);
+        ChatDto chat = ChattingMapper.toChatDto(chatMessage);
+
+        chatPublisher.sendMessage(chat.getChatRoomId(), chat);
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -7,11 +7,9 @@ import com.example.workoutmate.domain.chatting.repository.ChatMessageRepository;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
@@ -23,6 +21,7 @@ public class ChatMessageService {
     public ChatDto save(ChatDto chatDto, String email) {
         User sender = userService.findByEmail(email);
 
+        chatDto.setTypeTalk();
         ChatMessage chatMessage = ChattingMapper.toChatMessage(chatDto, sender);
 
         chatMessageRepository.save(chatMessage);

--- a/src/main/resources/static/stomp-test.html
+++ b/src/main/resources/static/stomp-test.html
@@ -106,7 +106,7 @@
         // }
 
         function fetchOldMessages(chatRoomId) {
-            const apiUrl = `http://localhost:8080/api/chat_rooms/message/${chatRoomId}?cursor=&size=50`;
+            const apiUrl = `http://localhost:8080/api/chat-rooms/message/${chatRoomId}?cursor=&size=50`;
             const token = $('#jwtToken').val();
 
             if (!token) {

--- a/src/main/resources/static/stomp-test.html
+++ b/src/main/resources/static/stomp-test.html
@@ -86,14 +86,33 @@
             const messageBox = $('#messageBox');
             // 메시지 객체에서 발신자와 메시지 내용을 추출하여 표시
             // const messageHtml = `<div class="alert alert-info"><strong>${msg.senderName}:</strong> ${msg.message} ${msg.createdAt}</div>`;
-            const messageHtml = `
-                <div class="alert alert-info d-flex justify-content-between align-items-center mb-1">
-                    <div>
-                        <strong>${msg.senderName}:</strong> ${msg.message}
-                    </div>
-                    <small class="text-muted">${msg.createdAt}</small>
+            // const messageHtml = `
+            //     <div class="alert alert-info d-flex justify-content-between align-items-center mb-1">
+            //         <div>
+            //             <strong>${msg.senderName}:</strong> ${msg.message}
+            //         </div>
+            //         <small class="text-muted">${msg.createdAt}</small>
+            //     </div>
+            // `;
+
+            let messageHtml = '';
+
+            if (msg.type === 'TALK') {
+                messageHtml = `
+            <div class="alert alert-info d-flex justify-content-between align-items-center mb-1">
+                <div>
+                    <strong>${msg.senderName}:</strong> ${msg.message}
                 </div>
-            `;
+                <small class="text-muted">${msg.createdAt}</small>
+            </div>
+        `;
+            } else if (msg.type === 'ENTER' || msg.type === 'LEAVE') {
+                messageHtml = `
+            <div class="alert alert-secondary text-center mb-1">
+                ${msg.message}
+            </div>
+        `;
+            }
             messageBox.append(messageHtml);
             messageBox.scrollTop(messageBox[0].scrollHeight);
         }
@@ -246,7 +265,8 @@
         <label for="message" class="form-label">MESSAGE(JSON):</label>
         <textarea id="message" class="form-control"
                   placeholder='{"targetUsername": "유저명", "message": "전송할 메시지", "sender": "발신자명"}'>
-{ "senderId" : 1, "message" : "안녕하세요?" }</textarea>
+{"type": "TALK", "message": "안녕하세요?"}
+</textarea>
     </div>
     <button id="sendBtn" class="btn btn-success">SEND</button>
 


### PR DESCRIPTION
### **📌 개요**
채팅 입장메시지, 퇴장메시지 구현, 메시지 발행 책임 분리

### **✅ 작업 사항**
채팅 입장, 퇴장 메시지를 구현하기 위해 ChatMessage 객체에 MessageType enum 필드를 추가하였습니다.
채팅 입장, 퇴장 메시지 기능을 구현하였고 테스트 페이지도 정상 노출되도록 수정하였습니다.
웹소켓으로 메시지를 발행하는 기능을 별도의 발행(Publisher) 클래스로 분리하였습니다.

### **🔍 리뷰 요청 포인트**

### **💬 기타 사항**
Chatting 쪽의 uri 변경이 있습니다.
포스트맨은 머지 후 수정하여 save 할 예정입니다