### PR TITLE
Feature(chatting): 에러 처리 로직, 토큰 갱신 확인 로직 추가

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/chatting/config/ChatAuthHandler.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/ChatAuthHandler.java
@@ -5,7 +5,6 @@ import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.example.workoutmate.global.exception.CustomException;
 import com.example.workoutmate.global.util.JwtUtil;
 import io.jsonwebtoken.Claims;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;

--- a/src/main/java/com/example/workoutmate/domain/chatting/config/StompExceptionHandler.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/StompExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.example.workoutmate.domain.chatting.config;
+
+import com.example.workoutmate.global.config.CustomUserPrincipal;
+import com.example.workoutmate.global.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class StompExceptionHandler {
+
+    private final SimpMessagingTemplate template;
+
+    public StompExceptionHandler(SimpMessagingTemplate template) {
+        this.template = template;
+    }
+
+    @MessageExceptionHandler(CustomException.class)
+    public void handleCustomException(CustomException e, CustomUserPrincipal principal) {
+        log.error("STOMP Error - USER: {}, Message: {}", principal.getName(), e.getMessage());
+
+        // 에러 정보를 담을 페이로드 생성
+        Map<String, Object> errorPayload = new HashMap<>();
+        errorPayload.put("error", e.getClass().getSimpleName());
+        errorPayload.put("message", e.getMessage());
+
+        // 에러 메시지 전송
+        template.convertAndSendToUser(
+                principal.getName(),
+                "/queue/errors",
+                errorPayload
+        );
+    }
+}

--- a/src/main/java/com/example/workoutmate/domain/chatting/config/StompExceptionHandler.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/StompExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.example.workoutmate.domain.chatting.config;
 
+import com.example.workoutmate.domain.chatting.event.ChatPublisher;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.example.workoutmate.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -12,13 +14,11 @@ import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class StompExceptionHandler {
 
     private final SimpMessagingTemplate template;
-
-    public StompExceptionHandler(SimpMessagingTemplate template) {
-        this.template = template;
-    }
+    private final ChatPublisher chatPublisher;
 
     @MessageExceptionHandler(CustomException.class)
     public void handleCustomException(CustomException e, CustomUserPrincipal principal) {
@@ -30,10 +30,6 @@ public class StompExceptionHandler {
         errorPayload.put("message", e.getMessage());
 
         // 에러 메시지 전송
-        template.convertAndSendToUser(
-                principal.getName(),
-                "/queue/errors",
-                errorPayload
-        );
+        chatPublisher.sendError(errorPayload, principal);
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/config/StompExceptionHandler.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/StompExceptionHandler.java
@@ -6,7 +6,6 @@ import com.example.workoutmate.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.HashMap;
@@ -17,7 +16,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class StompExceptionHandler {
 
-    private final SimpMessagingTemplate template;
     private final ChatPublisher chatPublisher;
 
     @MessageExceptionHandler(CustomException.class)

--- a/src/main/java/com/example/workoutmate/domain/chatting/config/WebSocketConfig.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/WebSocketConfig.java
@@ -20,10 +20,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 구독 경로 설정 - 목적지에서 메시지를 받을 수 있는 주소 설정
         registry.enableSimpleBroker(
                 "/sub/chat/mates"
+                , "/queue" // 에러 처리를 위한 주소
         );
 
         // 발행 경로 설정 - 해당 주소에서 메시지를 보냄
         registry.setApplicationDestinationPrefixes("/pub");
+
+        // convertAndSendToUser() 전송을 위한 설정
+        registry.setUserDestinationPrefix("/user");
     }
 
     @Override

--- a/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
@@ -4,6 +4,7 @@ import com.example.workoutmate.domain.chatting.dto.ChatDto;
 import com.example.workoutmate.domain.chatting.service.ChatMessageService;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
@@ -16,10 +17,19 @@ public class ChatController {
 
     private final ChatMessageService chatMessageService;
 
+    // 채팅 전송 요청
     @MessageMapping("/chats/send-message")
     public void sendMessage(@Payload ChatDto chat,
                             CustomUserPrincipal user) {
 
         chatMessageService.saveAndSend(chat, user.getEmail());
+    }
+
+    // 토큰 갱신 요청
+    @MessageMapping("/chat.ping")
+    public void handlePing(@Header("Authorization") String token,
+                           CustomUserPrincipal user) {
+
+        chatMessageService.sendPingError(token, user);
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/controller/ChatController.java
@@ -20,6 +20,6 @@ public class ChatController {
     public void sendMessage(@Payload ChatDto chat,
                             CustomUserPrincipal user) {
 
-        chatMessageService.save(chat, user.getEmail());
+        chatMessageService.saveAndSend(chat, user.getEmail());
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/event/ChatPublisher.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/event/ChatPublisher.java
@@ -1,9 +1,12 @@
 package com.example.workoutmate.domain.chatting.event;
 
 import com.example.workoutmate.domain.chatting.dto.ChatDto;
+import com.example.workoutmate.global.config.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 /**
  * WebSocket 메시지 발행(Publishing)을 전담하는 클래스
@@ -16,5 +19,13 @@ public class ChatPublisher {
 
     public void sendMessage(Long chatRoomId, ChatDto message) {
         template.convertAndSend("/sub/chat/mates/" + chatRoomId, message);
+    }
+
+    public void sendError(Map<String, Object> errorPayload, CustomUserPrincipal principal) {
+        template.convertAndSendToUser(
+                principal.getName(),
+                "/queue/errors",
+                errorPayload
+        );
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -2,27 +2,46 @@ package com.example.workoutmate.domain.chatting.service;
 
 import com.example.workoutmate.domain.chatting.dto.ChatDto;
 import com.example.workoutmate.domain.chatting.entity.ChatMessage;
+import com.example.workoutmate.domain.chatting.entity.ChatRoomMember;
 import com.example.workoutmate.domain.chatting.entity.ChattingMapper;
 import com.example.workoutmate.domain.chatting.event.ChatPublisher;
 import com.example.workoutmate.domain.chatting.repository.ChatMessageRepository;
+import com.example.workoutmate.domain.chatting.repository.ChatRoomMemberRepository;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.service.UserService;
+import com.example.workoutmate.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.workoutmate.global.enums.CustomErrorCode.ALREADY_LEFT_CHATROOM;
+import static com.example.workoutmate.global.enums.CustomErrorCode.CHATROOM_MEMBER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final UserService userService;
     private final ChatPublisher chatPublisher;
 
     @Transactional
-    public void save(ChatDto chatDto, String email) {
+    public void saveAndSend(ChatDto chatDto, String email) {
         User sender = userService.findByEmail(email);
 
+        // 채팅방 퇴장 여부 확인 로직
+        // 1. 채팅방 멤버 정보 조회
+        ChatRoomMember member = chatRoomMemberRepository.findByChatRoomIdAndUserId(chatDto.getChatRoomId(), sender.getId())
+                .orElseThrow(() -> new CustomException(CHATROOM_MEMBER_NOT_FOUND, "채팅방의 멤버가 아닙니다."));
+
+        // 2. 해당 채팅방에서 나갔는지(isJoined == false) 확인
+        if (!member.isJoined()) {
+            // STOMP 예외 처리 핸들러에서 처리할 수 있는 특정 예외를 발생시키는 것이 좋음
+            throw new CustomException(ALREADY_LEFT_CHATROOM, "이미 퇴장한 채팅방에서는 메시지를 보낼 수 없습니다.");
+        }
+
+        // 메시지 전송
         chatDto.setTypeTalk();
         ChatMessage chatMessage = ChattingMapper.toChatMessage(chatDto, sender);
 

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -12,14 +12,12 @@ import com.example.workoutmate.domain.user.service.UserService;
 import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.example.workoutmate.global.exception.CustomException;
 import com.example.workoutmate.global.util.JwtUtil;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
-
-import static com.example.workoutmate.global.enums.CustomErrorCode.ALREADY_LEFT_CHATROOM;
-import static com.example.workoutmate.global.enums.CustomErrorCode.CHATROOM_MEMBER_NOT_FOUND;
+import static com.example.workoutmate.global.enums.CustomErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -59,11 +57,11 @@ public class ChatMessageService {
 
 
     public void sendPingError(String token, CustomUserPrincipal authUser) {
-        if (jwtUtil.validateToken(token)) {
-            Map<String, Object> errorPayload = Map.of(
-                    "error", "세션이 만료되었습니다. 다시 로그인해주세요."
-            );
-            chatPublisher.sendError(errorPayload, authUser);
+        Claims claims = jwtUtil.extractClaims(jwtUtil.substringToken(token));
+        String email = claims.get("email", String.class);
+
+        if (!email.equals(authUser.getEmail())) {
+            throw new CustomException(TOKEN_USER_MISMATCH, TOKEN_USER_MISMATCH.getMessage() + " 다시 로그인해주세요.");
         }
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -9,10 +9,14 @@ import com.example.workoutmate.domain.chatting.repository.ChatMessageRepository;
 import com.example.workoutmate.domain.chatting.repository.ChatRoomMemberRepository;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.service.UserService;
+import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.example.workoutmate.global.exception.CustomException;
+import com.example.workoutmate.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 import static com.example.workoutmate.global.enums.CustomErrorCode.ALREADY_LEFT_CHATROOM;
 import static com.example.workoutmate.global.enums.CustomErrorCode.CHATROOM_MEMBER_NOT_FOUND;
@@ -25,17 +29,18 @@ public class ChatMessageService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final UserService userService;
     private final ChatPublisher chatPublisher;
+    private final JwtUtil jwtUtil;
 
     @Transactional
     public void saveAndSend(ChatDto chatDto, String email) {
         User sender = userService.findByEmail(email);
 
-        // 채팅방 퇴장 여부 확인 로직
+        // 채팅방 퇴장 여부 확인
         // 1. 채팅방 멤버 정보 조회
         ChatRoomMember member = chatRoomMemberRepository.findByChatRoomIdAndUserId(chatDto.getChatRoomId(), sender.getId())
                 .orElseThrow(() -> new CustomException(CHATROOM_MEMBER_NOT_FOUND, "채팅방의 멤버가 아닙니다."));
 
-        // 2. 해당 채팅방에서 나갔는지(isJoined == false) 확인
+        // 2. 해당 채팅방에서 나갔는지 확인
         if (!member.isJoined()) {
             // STOMP 예외 처리 핸들러에서 처리할 수 있는 특정 예외를 발생시키는 것이 좋음
             throw new CustomException(ALREADY_LEFT_CHATROOM, "이미 퇴장한 채팅방에서는 메시지를 보낼 수 없습니다.");
@@ -50,5 +55,15 @@ public class ChatMessageService {
         ChatDto chat = ChattingMapper.toChatDto(chatMessage);
 
         chatPublisher.sendMessage(chat.getChatRoomId(), chat);
+    }
+
+
+    public void sendPingError(String token, CustomUserPrincipal authUser) {
+        if (jwtUtil.validateToken(token)) {
+            Map<String, Object> errorPayload = Map.of(
+                    "error", "세션이 만료되었습니다. 다시 로그인해주세요."
+            );
+            chatPublisher.sendError(errorPayload, authUser);
+        }
     }
 }

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChattingService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChattingService.java
@@ -68,8 +68,12 @@ public class ChattingService {
         if (existingRoom.isPresent()) {
             ChatRoom chatRoom = existingRoom.get();
 
-            ChatRoomMember chatRoomMember = chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoom.getId(), sender.getId()).orElseThrow(
-                    () -> new CustomException(CHATROOM_MEMBER_NOT_FOUND, CHATROOM_MEMBER_NOT_FOUND.getMessage()));
+            if (chatRoom.isDeleted()) {
+                throw new CustomException(CHATROOM_DELETED, CHATROOM_DELETED.getMessage());
+            }
+
+            ChatRoomMember chatRoomMember = getChatRoomMemberByChatRoomIdAndUserId(
+                    chatRoom.getId(), sender.getId());
 
             chatRoomMember.join();
 
@@ -210,5 +214,11 @@ public class ChattingService {
     private ChatRoom findChatRoomById(Long chatRoomId) {
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new CustomException(CHATROOM_NOT_FOUND, CHATROOM_NOT_FOUND.getMessage()));
+    }
+
+    // 채팅방 id와 유저 id로 채팅방 멤버 객체 반환
+    private ChatRoomMember getChatRoomMemberByChatRoomIdAndUserId(Long chatRoomId, Long userId) {
+        return chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoomId, userId).orElseThrow(
+                () -> new CustomException(CHATROOM_MEMBER_NOT_FOUND, CHATROOM_MEMBER_NOT_FOUND.getMessage()));
     }
 }

--- a/src/main/java/com/example/workoutmate/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/workoutmate/global/config/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
 
         // 허용할 출처(Origin)를 명시적으로 지정
         configuration.setAllowedOrigins(
-                List.of("http://localhost:63342", "https://jiangxy.github.io")
+                List.of("http://localhost:63355", "https://jiangxy.github.io")
         );
 
         // 허용할 HTTP 메서드 설정

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -18,6 +18,7 @@ public enum CustomErrorCode {
     SERVER_EXCEPTION_JWT(HttpStatus.INTERNAL_SERVER_ERROR, "Not Found Token"),
     SC_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 서명입니다."),
     SC_BAD_REQUEST(HttpStatus.BAD_REQUEST,"지원되지 않는 JWT 토큰입니다."),
+    EXPIRED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "만료된 JWT 토큰입니다."),
     SC_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패 했습니다"),
     EMAIL_NOT_VERIFIED_FOR_SIGNUP(HttpStatus.CONFLICT,  "이미 가입 대기 중인 이메일입니다. 인증코드를 다시 받으려면 [재발송] 버튼을 눌러주세요."),

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -61,6 +61,7 @@ public enum CustomErrorCode {
     CHATROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 멤버가 존재하지 않습니다."),
     ALREADY_LEFT_CHATROOM(HttpStatus.BAD_REQUEST, "이미 채팅방을 나간 유저입니다."),
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "헤더에 JWT 토큰이 존재하지 않습니다."),
+    TOKEN_USER_MISMATCH(HttpStatus.BAD_REQUEST, "유저 정보가 일치하지 않습니다."),
 
     // Zzim
     ALREADY_ZZIM(HttpStatus.CONFLICT, "이미 찜한 게시글입니다."),

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -57,6 +57,7 @@ public enum CustomErrorCode {
     // Chatting
     EQUALS_SENDER_RECEIVER(HttpStatus.BAD_REQUEST, "본인과는 채팅방을 생성할 수 없습니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+    CHATROOM_DELETED(HttpStatus.BAD_REQUEST, "삭제된 채팅방입니다."),
     CHATROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방 멤버가 존재하지 않습니다."),
     ALREADY_LEFT_CHATROOM(HttpStatus.BAD_REQUEST, "이미 채팅방을 나간 유저입니다."),
     TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "헤더에 JWT 토큰이 존재하지 않습니다."),

--- a/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
+++ b/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
@@ -64,13 +64,4 @@ public class JwtUtil {
                 .parseClaimsJws(token)
                 .getBody();
     }
-
-    public boolean validateToken(String token) {
-        try {
-            extractClaims(substringToken(token));
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
-        }
-    }
 }

--- a/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
+++ b/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
@@ -4,6 +4,7 @@ import com.example.workoutmate.domain.user.enums.UserRole;
 import com.example.workoutmate.global.enums.CustomErrorCode;
 import com.example.workoutmate.global.exception.CustomException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -62,5 +63,14 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            extractClaims(substringToken(token));
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
+++ b/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
@@ -3,9 +3,7 @@ package com.example.workoutmate.global.util;
 import com.example.workoutmate.domain.user.enums.UserRole;
 import com.example.workoutmate.global.enums.CustomErrorCode;
 import com.example.workoutmate.global.exception.CustomException;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +14,9 @@ import org.springframework.util.StringUtils;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+
+import static com.example.workoutmate.global.enums.CustomErrorCode.EXPIRED_JWT_TOKEN;
+import static com.example.workoutmate.global.enums.CustomErrorCode.SC_UNAUTHORIZED;
 
 @Slf4j(topic = "jwtUtil")
 @Component
@@ -57,10 +58,16 @@ public class JwtUtil {
     }
 
     public Claims extractClaims(String token){
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(EXPIRED_JWT_TOKEN, EXPIRED_JWT_TOKEN.getMessage());
+        } catch (JwtException e) {
+            throw new CustomException(SC_UNAUTHORIZED, SC_UNAUTHORIZED.getMessage());
+        }
     }
 }

--- a/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
+++ b/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
@@ -4,7 +4,6 @@ import com.example.workoutmate.domain.user.enums.UserRole;
 import com.example.workoutmate.global.enums.CustomErrorCode;
 import com.example.workoutmate.global.exception.CustomException;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/resources/static/stomp-test.html
+++ b/src/main/resources/static/stomp-test.html
@@ -24,15 +24,10 @@
             const url = $('#websocketUrl').val();
             const token = $('#jwtToken').val();
 
-            // if (!token) {
-            //     alert('JWT Token을 입력해주세요.');
-            //     return;
-            // }
-
-            // STOMP 연결 시 헤더에 인증 정보 추가
-            const connectHeaders = {
-                Authorization: `Bearer ${token}`
-            };
+            if (!chatRoomId || !token) {
+                alert('JWT Tokenr과 채팅방 ID를 모두 입력해주세요.');
+                return;
+            }
 
             const urlWithToken = `${url}?token=${token}`;
 
@@ -47,10 +42,13 @@
             }, () => {
                 console.log('connected!');
 
+                subscribeErrorQueue();
+
                 fetchOldMessages(chatRoomId); // 1. 이전 메시지 먼저 로딩
 
                 const subPath = `/sub/chat/rooms/${chatRoomId}`; // 2. 구독 경로
                 subscribeToPath(subPath); // 3. 실시간 메시지 구독 시작
+
             }, stompErrorHandler);
         }
 
@@ -60,6 +58,22 @@
 
         function stompErrorHandler(e) {
             console.error('stomp connect error - ', e);
+        }
+
+        function subscribeErrorQueue() {
+            stompClient.subscribe('/user/queue/errors', function(error) {
+                try {
+                    const errorPayload = JSON.parse(error.body);
+                    console.error('[STOMP 에러 수신]');
+                    console.error('에러 타입:', errorPayload.error);
+                    console.error('에러 메시지:', errorPayload.message);
+
+                    // 사용자 알림
+                    alert("메시지 전송 실패: " + errorPayload.message);
+                } catch (e) {
+                    console.error('[STOMP 에러 수신 실패] 올바른 JSON이 아닙니다.', error.body);
+                }
+            });
         }
 
         function subscribeToPath(path) {
@@ -85,15 +99,6 @@
         function displayMessage(msg) {
             const messageBox = $('#messageBox');
             // 메시지 객체에서 발신자와 메시지 내용을 추출하여 표시
-            // const messageHtml = `<div class="alert alert-info"><strong>${msg.senderName}:</strong> ${msg.message} ${msg.createdAt}</div>`;
-            // const messageHtml = `
-            //     <div class="alert alert-info d-flex justify-content-between align-items-center mb-1">
-            //         <div>
-            //             <strong>${msg.senderName}:</strong> ${msg.message}
-            //         </div>
-            //         <small class="text-muted">${msg.createdAt}</small>
-            //     </div>
-            // `;
 
             let messageHtml = '';
 

--- a/src/main/resources/static/stomp-test.html
+++ b/src/main/resources/static/stomp-test.html
@@ -19,6 +19,7 @@
 
         let stompClient; // stompClient 변수를 전역으로 설정
         let subscriptions = {}; // 구독 정보를 저장할 객체
+        let pingIntervalId; // 토큰 인증을 위한 ping 객체
 
         function connectWebSocket(chatRoomId) {
             const url = $('#websocketUrl').val();
@@ -49,6 +50,8 @@
                 const subPath = `/sub/chat/rooms/${chatRoomId}`; // 2. 구독 경로
                 subscribeToPath(subPath); // 3. 실시간 메시지 구독 시작
 
+                startPingInterval(); // 4. 5분마다 ping 전송 및 토큰 확인
+
             }, stompErrorHandler);
         }
 
@@ -58,6 +61,7 @@
 
         function stompErrorHandler(e) {
             console.error('stomp connect error - ', e);
+
         }
 
         function subscribeErrorQueue() {
@@ -70,10 +74,24 @@
 
                     // 사용자 알림
                     alert("메시지 전송 실패: " + errorPayload.message);
+
+                    disconnectWebSocket();
+
                 } catch (e) {
                     console.error('[STOMP 에러 수신 실패] 올바른 JSON이 아닙니다.', error.body);
                 }
             });
+        }
+
+        function disconnectWebSocket() {
+            // 연결 종료 시 ping 삭제
+            clearPing();
+
+            if (stompClient) {
+                stompClient.disconnect(() => {
+                    console.log("WebSocket disconnected");
+                })
+            }
         }
 
         function subscribeToPath(path) {
@@ -93,6 +111,40 @@
                 delete subscriptions[path]; // 구독 정보 삭제
                 console.log(`Unsubscribed from ${path}`);
             }
+        }
+
+        function clearPing() {
+            if (pingIntervalId !== null) {
+                clearInterval(pingIntervalId);
+                pingIntervalId = null;
+            }
+        }
+
+        function startPingInterval() {
+            const token = $('#jwtToken').val();
+
+            clearPing();
+
+            pingIntervalId = setInterval(() => {
+
+                // 연결 안되어 있는 상태면 ping 종료
+                if (!stompClient || !stompClient.connected) {
+                    clearInterval(pingIntervalId);
+                    pingIntervalId = null;
+                    console.log("ping interval cleared");
+                    return;
+                }
+
+                console.log("[PING] 30초마다 ping을 전송합니다", new Date());
+                if (stompClient && stompClient.connected) {
+                    stompClient.send(
+                        '/pub/chat.ping',
+                        { Authorization: `Bearer ${token}` },
+                        JSON.stringify({ timestamp: Date.now() })
+                    );
+                    console.log("ping 전송됨");
+                }
+            }, 30 * 1000); // 30초마다 전송
         }
 
         // -- 수정된 부분: 메시지 객체를 받아 화면에 표시하도록 변경

--- a/src/main/resources/static/stomp-test.html
+++ b/src/main/resources/static/stomp-test.html
@@ -121,8 +121,6 @@
         }
 
         function startPingInterval() {
-            const token = $('#jwtToken').val();
-
             clearPing();
 
             pingIntervalId = setInterval(() => {
@@ -135,11 +133,13 @@
                     return;
                 }
 
+                const currentToken = $('#jwtToken').val();
+
                 console.log("[PING] 30초마다 ping을 전송합니다", new Date());
                 if (stompClient && stompClient.connected) {
                     stompClient.send(
                         '/pub/chat.ping',
-                        { Authorization: `Bearer ${token}` },
+                        { Authorization: `Bearer ${currentToken}` },
                         JSON.stringify({ timestamp: Date.now() })
                     );
                     console.log("ping 전송됨");


### PR DESCRIPTION
### **📌 개요**
에러 처리 로직, 토큰 갱신 확인 로직 추가

### **✅ 작업 사항**
이제 서버에서 CustomException이 발생하면 프론트 콘솔에서 에러 메시지 내용을 확인할 수 있습니다.

프론트에서 주기적으로 토큰과 함께 ping을 전달하면 서버에서 토큰 확인 로직을 실행합니다.
그리고 첫 연결 시의 유저 이메일과 갱신된 토큰의 유저 이메일이 다르면 웹소켓 연결을 해제할 수 있습니다.

### **🔍 리뷰 요청 포인트**
### **💬 기타 사항**
튜터님이 말씀해주신 SecurityConfig 파일에 health-check 경로 허용이 따로 없는데 별도로 추가 안해도 될지 확인 부탁드립니다.