### PR TITLE
Feature/token

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/chatting/config/ChatAuthHandler.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/config/ChatAuthHandler.java
@@ -33,7 +33,7 @@ public class ChatAuthHandler implements ChannelInterceptor {
             String token = jwtUtil.substringToken(jwtToken);
 
             try {
-                Claims claims = jwtUtil.extractClaims(token);
+                Claims claims = jwtUtil.parseToken(token).getBody();
 
                 if (claims == null) {
                     throw new CustomException(TOKEN_NOT_FOUND, TOKEN_NOT_FOUND.getMessage());

--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -57,7 +57,7 @@ public class ChatMessageService {
 
 
     public void sendPingError(String token, CustomUserPrincipal authUser) {
-        Claims claims = jwtUtil.extractClaims(jwtUtil.substringToken(token));
+        Claims claims = jwtUtil.parseToken(jwtUtil.substringToken(token)).getBody();
         String email = claims.get("email", String.class);
 
         if (!email.equals(authUser.getEmail())) {

--- a/src/main/java/com/example/workoutmate/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/workoutmate/domain/user/controller/AuthController.java
@@ -12,10 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -88,4 +85,11 @@ public class AuthController {
         return ApiResponse.success(HttpStatus.OK, "토큰이 갱신되었습니다.", newTokens);
     }
 
+    @PostMapping("/auth/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @RequestHeader("Authorization") String accessToken,
+            @CookieValue(name = "refreshToken", required = false) String refreshToken){
+        authService.logout(accessToken, refreshToken);
+        return ApiResponse.success(HttpStatus.OK, "로그아웃 되었습니다.", null);
+    }
 }

--- a/src/main/java/com/example/workoutmate/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/workoutmate/domain/user/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.example.workoutmate.domain.user.controller;
 import com.example.workoutmate.domain.user.dto.*;
 import com.example.workoutmate.domain.user.service.AuthService;
 import com.example.workoutmate.global.dto.ApiResponse;
+import com.example.workoutmate.global.enums.CustomErrorCode;
+import com.example.workoutmate.global.exception.CustomException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +24,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<ApiResponse<AuthResponseDto>> signup(@Valid @RequestBody SignupRequestDto signupRequestDto){
+    public ResponseEntity<ApiResponse<AuthResponseDto>> signup(@Valid @RequestBody SignupRequestDto signupRequestDto) {
         AuthResponseDto signup = authService.signup(signupRequestDto);
         return ApiResponse.success(HttpStatus.OK, "회원가입을 성공했습니다. 이메일 인증을 해주세요.", signup);
     }
@@ -33,29 +36,56 @@ public class AuthController {
     }
 
     @PostMapping("/auth/signup/resend")
-    public ResponseEntity<ApiResponse<Void>> resendEmail(@Valid @RequestBody ResendEmailRequestDto resendEmailRequestDto){
+    public ResponseEntity<ApiResponse<Void>> resendEmail(@Valid @RequestBody ResendEmailRequestDto resendEmailRequestDto) {
         authService.resendEmail(resendEmailRequestDto);
         return ApiResponse.success(HttpStatus.OK, "이메일 인증 코드가 재발송되었습니다.", null);
     }
 
     @PostMapping("/auth/login")
     public ResponseEntity<ApiResponse<LoginResponseDto>> login(@Valid @RequestBody LoginRequestDto loginRequestDto,
-                                                               HttpServletResponse response){
+                                                               HttpServletResponse response) {
         LoginResponseDto login = authService.login(loginRequestDto);
-        response.addHeader(HttpHeaders.AUTHORIZATION, login.getAccessToken());
+        response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + login.getAccessToken());
 
         // refreshToken 을 HttpOnly 쿠키로 저장 (보안 강화)
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", login.getRefreshToken())
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(7*24*60*60)
+                .maxAge(7 * 24 * 60 * 60)
                 .sameSite("Strict")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         return ApiResponse.success(HttpStatus.OK, "로그인이 완료되었습니다.", login);
+    }
+
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<ApiResponse<LoginResponseDto>> refreshToken(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response) {
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new CustomException(CustomErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        // 검증 + 새 토큰 발급
+        LoginResponseDto newTokens = authService.refreshAccessToken(refreshToken);
+
+        // 헤더/쿠키 세팅
+        response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + newTokens.getAccessToken());
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", newTokens.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(7 * 24 * 60 * 60)
+                .sameSite("Strict")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ApiResponse.success(HttpStatus.OK, "토큰이 갱신되었습니다.", newTokens);
     }
 
 }

--- a/src/main/java/com/example/workoutmate/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/workoutmate/domain/user/dto/LoginResponseDto.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class LoginResponseDto {
-    private String token;
+    private final String accessToken;
+    private final String refreshToken;
 }

--- a/src/main/java/com/example/workoutmate/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/workoutmate/domain/user/repository/UserRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmailAndIsDeletedFalse(String email);
     Optional<User> findByEmailAndIsDeletedFalse(String email);
-    Optional<User> findByIdAndIsDeletedFalse(Long id);
+    Optional<User> findByIdAndIsDeletedFalseAndIsEmailVerifiedTrue(Long id);
 
 
     boolean existsByEmailAndIsDeletedFalseAndIsEmailVerifiedTrue(String email);

--- a/src/main/java/com/example/workoutmate/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/workoutmate/domain/user/service/AuthService.java
@@ -98,9 +98,11 @@ public class AuthService {
             throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCHED);
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole());
+        // 토큰 발급
+        String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getRole());
+        String refreshToken = jwtUtil.createRefreshToken(user.getId());
 
-        return new LoginResponseDto(bearerToken);
+        return new LoginResponseDto(accessToken, refreshToken);
     }
 
     @Transactional

--- a/src/main/java/com/example/workoutmate/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/workoutmate/domain/user/service/AuthService.java
@@ -130,6 +130,9 @@ public class AuthService {
         User user = userRepository.findByIdAndIsDeletedFalseAndIsEmailVerifiedTrue(userId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.USER_NOT_FOUND));
 
+        // 기존 refresh 토큰 Redis 에서 삭제
+        refreshTokenService.deleteRefreshTokenJti(jti);
+
         // 토큰 발급 및 저장
         return generateAndSaveToken(user);
     }

--- a/src/main/java/com/example/workoutmate/domain/user/service/RefreshTokenService.java
+++ b/src/main/java/com/example/workoutmate/domain/user/service/RefreshTokenService.java
@@ -1,0 +1,25 @@
+package com.example.workoutmate.domain.user.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@AllArgsConstructor
+public class RefreshTokenService {
+    private final StringRedisTemplate redisTemplate;
+
+    public void saveRefreshTokenJti(String jti, Long userId){
+        redisTemplate.opsForValue().set("refresh:"+jti, userId.toString(), 7, TimeUnit.DAYS);
+    }
+
+    public Long getUserIdByJti(String jti){
+        return Long.valueOf(redisTemplate.opsForValue().get("refresh:"+ jti));
+    }
+
+    public void deleteRefreshTokenJti(String jti){
+        redisTemplate.delete("refresh:"+jti);
+    }
+}

--- a/src/main/java/com/example/workoutmate/domain/user/service/TokenBlacklistService.java
+++ b/src/main/java/com/example/workoutmate/domain/user/service/TokenBlacklistService.java
@@ -1,0 +1,24 @@
+package com.example.workoutmate.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    // blacklist 에 토큰 추가
+    public void addToBlacklist(String jti, Duration ttl){
+        redisTemplate.opsForValue().set("blacklist:"+jti, "true", ttl);
+    }
+
+    // blacklist 에 있는 토큰인지 검증
+    public boolean isBlacklisted(String jti){
+        return redisTemplate.hasKey("blacklist:"+jti);
+    }
+}

--- a/src/main/java/com/example/workoutmate/domain/user/service/UserService.java
+++ b/src/main/java/com/example/workoutmate/domain/user/service/UserService.java
@@ -114,7 +114,7 @@ public class UserService {
     /* 도메인 관련 메서드 */
 
     public User findById(Long id) {
-        return userRepository.findByIdAndIsDeletedFalse(id).orElseThrow(
+        return userRepository.findByIdAndIsDeletedFalseAndIsEmailVerifiedTrue(id).orElseThrow(
                 () -> new CustomException(USER_NOT_FOUND, USER_NOT_FOUND.getMessage()));
     }
 

--- a/src/main/java/com/example/workoutmate/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/workoutmate/global/config/JwtAuthenticationFilter.java
@@ -50,10 +50,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = jwtUtil.substringToken(bearerJwt);
 
+        // 토큰이 있는 경우
         try {
-            Claims claims = jwtUtil.extractClaims(token);
-            if (claims == null) {
-                httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다.");
+            var jws = jwtUtil.parseToken(token);
+            String jti = jws.getBody().getId();
+            // jti 가 블랙리스트에 있는지 검증
+            if(jti != null && blacklist.isBlacklisted(jti)){
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                log.error("만료된 토큰으로 접근을 시도했습니다.");
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그아웃된 사용자입니다.");
                 return;
             }
 

--- a/src/main/java/com/example/workoutmate/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/workoutmate/global/config/JwtAuthenticationFilter.java
@@ -1,8 +1,8 @@
 package com.example.workoutmate.global.config;
 
 import com.example.workoutmate.domain.user.enums.UserRole;
+import com.example.workoutmate.domain.user.service.TokenBlacklistService;
 import com.example.workoutmate.global.util.JwtUtil;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -14,14 +14,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
 import java.io.IOException;
-import java.security.SignatureException;
-import java.util.Collections;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,6 +25,7 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final TokenBlacklistService blacklist;
 
     @Override
     protected void doFilterInternal(
@@ -45,6 +42,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
+        // 리프레시 토큰 검사에서 제외
+        if ("/api/auth/refresh".equals(request.getRequestURI())){
+            filterChain.doFilter(request,response);
+            return;
+        }
+
         String token = jwtUtil.substringToken(bearerJwt);
 
         try {
@@ -55,22 +58,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             // 사용자 정보 추출
-            Long userId = Long.valueOf(claims.getSubject());
-            String email = claims.get("email").toString();
-            UserRole userRole = UserRole.valueOf(claims.get("userRole", String.class));
+            Long userId = Long.valueOf(jws.getBody().getSubject());
+            String email = jws.getBody().get("email", String.class);
+            UserRole role = UserRole.valueOf((String) jws.getBody().get("userRole"));
 
-            CustomUserPrincipal customUserPrincipal = new CustomUserPrincipal(userId, email, userRole);
+            CustomUserPrincipal customUserPrincipal = new CustomUserPrincipal(userId, email, role);
 
             // SecurityContext 에 인증 등록
             Authentication authentication = new UsernamePasswordAuthenticationToken(
-                    customUserPrincipal,
-                    null,
-                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + userRole.name()))
-            );
+                    customUserPrincipal,null, customUserPrincipal.getAuthorities());
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            filterChain.doFilter(request, response);
         } catch (MalformedJwtException | SecurityException e) {
             log.error("Invalid JWT signature, 유효하지 않은 JWT 서명입니다.", e);
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 서명입니다.");
@@ -88,5 +87,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰 입니다.");
             return;
         }
+        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/example/workoutmate/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/workoutmate/global/config/JwtAuthenticationFilter.java
@@ -87,10 +87,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰 입니다.");
             return;
-        } catch (Exception e) {
-            log.error("Internal server error", e);
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러입니다.");
-            return;
         }
     }
 }

--- a/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
+++ b/src/main/java/com/example/workoutmate/global/enums/CustomErrorCode.java
@@ -26,6 +26,8 @@ public enum CustomErrorCode {
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증코드가 만료되었습니다. 재발송 요청 후 다시 시도해 주세요."),
     EMAIL_NOT_VERIFIED_FOR_LOGIN(HttpStatus.UNAUTHORIZED,  "이메일 인증이 완료되지 않았습니다"),
     ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증된 사용자 입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh token이 없습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "유효하지 않은 refresh token 입니다."),
 
     // User
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),

--- a/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
+++ b/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
@@ -23,8 +23,7 @@ import java.util.UUID;
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    // test 용 1분
-    private static final long TOKEN_TIME = 1 * 60 * 1000L; // 1 분
+    private static final long ACCESS_TOKEN_TIME = 15 * 60 * 1000L; // 15 분
     private static final long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
     private final TokenBlacklistService tokenBlacklistService;
     private final RefreshTokenService refreshTokenService;
@@ -55,12 +54,13 @@ public class JwtUtil {
                         .setId(jti)
                         .claim("email", email)
                         .claim("userRole", userRole)
-                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME))
                         .setIssuedAt(date)
                         .signWith(key, signatureAlgorithm)
                         .compact();
     }
 
+    // Bearer 제거한 토큰 값만 추출
     public String substringToken(String tokenValue) {
         if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
             return tokenValue.substring(7);
@@ -68,7 +68,7 @@ public class JwtUtil {
         throw new CustomException(CustomErrorCode.SERVER_EXCEPTION_JWT);
     }
 
-    // 토큰 추출
+    // jwt 토큰 추출
     public Jws<Claims> parseToken(String token) throws JwtException {
         return Jwts.parserBuilder()
                 .setSigningKey(key)

--- a/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
+++ b/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
@@ -1,6 +1,8 @@
 package com.example.workoutmate.global.util;
 
 import com.example.workoutmate.domain.user.enums.UserRole;
+import com.example.workoutmate.domain.user.service.RefreshTokenService;
+import com.example.workoutmate.domain.user.service.TokenBlacklistService;
 import com.example.workoutmate.global.enums.CustomErrorCode;
 import com.example.workoutmate.global.exception.CustomException;
 import io.jsonwebtoken.*;
@@ -14,22 +16,28 @@ import org.springframework.util.StringUtils;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
-
-import static com.example.workoutmate.global.enums.CustomErrorCode.EXPIRED_JWT_TOKEN;
-import static com.example.workoutmate.global.enums.CustomErrorCode.SC_UNAUTHORIZED;
+import java.util.UUID;
 
 @Slf4j(topic = "jwtUtil")
 @Component
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final long TOKEN_TIME = 10 * 60 * 1000L; // 10 분
+    // test 용 1분
+    private static final long TOKEN_TIME = 1 * 60 * 1000L; // 1 분
     private static final long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
+    private final TokenBlacklistService tokenBlacklistService;
+    private final RefreshTokenService refreshTokenService;
 
     @Value("${SECRET_KEY}")
     private String secretKey;
     private Key key;
     private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    public JwtUtil(TokenBlacklistService tokenBlacklistService, RefreshTokenService refreshTokenService) {
+        this.tokenBlacklistService = tokenBlacklistService;
+        this.refreshTokenService = refreshTokenService;
+    }
 
     @PostConstruct
     public void init() {
@@ -39,10 +47,12 @@ public class JwtUtil {
 
     public String createAccessToken(Long userId, String email, UserRole userRole) {
         Date date = new Date();
+        String jti = UUID.randomUUID().toString();
 
         return BEARER_PREFIX +
                 Jwts.builder()
                         .setSubject(String.valueOf(userId))
+                        .setId(jti)
                         .claim("email", email)
                         .claim("userRole", userRole)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
@@ -58,38 +68,81 @@ public class JwtUtil {
         throw new CustomException(CustomErrorCode.SERVER_EXCEPTION_JWT);
     }
 
-    public Claims extractClaims(String token) {
-        try {
-            return Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-        } catch (ExpiredJwtException e) {
-            throw new CustomException(EXPIRED_JWT_TOKEN, EXPIRED_JWT_TOKEN.getMessage());
-        } catch (JwtException e) {
-            throw new CustomException(SC_UNAUTHORIZED, SC_UNAUTHORIZED.getMessage());
-        }
+    // 토큰 추출
+    public Jws<Claims> parseToken(String token) throws JwtException {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
     }
 
-    public boolean validateToken(String token){
-        try{
-            Claims claims = extractClaims(token);
-            return !claims.getExpiration().before(new Date());
-        } catch(Exception e){
-            return false;
-        }
+    // Jti(access token 고유 식별자) 추출
+    public String getJti(String token) {
+        return parseToken(token).getBody().getId();
+    }
+
+    // Expiration(만료일) 추출
+    public Date getExpiration(String token) {
+        return parseToken(token).getBody().getExpiration();
     }
 
     // refresh token
-    public String createRefreshToken(Long userId){
+    public String createRefreshToken(Long userId) {
         Date date = new Date();
+        String jti = UUID.randomUUID().toString();
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
-                .setExpiration(new Date(date.getTime()+REFRESH_TOKEN_TIME))
+                .setId(jti)
+                .setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))
                 .setIssuedAt(date)
                 .signWith(key, signatureAlgorithm)
                 .compact();
     }
+
+    // 토큰 유효성 검증
+    public boolean validateAccessToken(String token) {
+        try {
+            Jws<Claims> claims = parseToken(token);
+            // 블랙리스트에 있는지 확인
+            String jti = claims.getBody().getId();
+            if (tokenBlacklistService.isBlacklisted(jti)) {
+                return false;
+            }
+            return true;
+        } // 토큰 만료
+        catch (ExpiredJwtException e) {
+            log.warn("JWT expired at {}", e.getClaims().getExpiration());
+            return false;
+        } // 서명 불일치, 구조 손상, 잘못된 인자 등
+        catch (JwtException | IllegalArgumentException e) {
+            log.warn("Invalid JWT: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    // 리프레시 토큰 유효성 검증
+    public boolean validateRefreshToken(String refreshToken){
+        try{
+            // 토큰 파싱
+            Claims claims = parseToken(refreshToken).getBody();
+            String jti = claims.getId();
+            Long userIdFromRedis = refreshTokenService.getUserIdByJti(jti);
+            if(userIdFromRedis == null ){
+                return false;
+            }
+
+            Long userIdFromToken = Long.valueOf(claims.getSubject());
+            return userIdFromToken.equals(userIdFromRedis);
+        }
+        catch (ExpiredJwtException e) {
+            log.warn("JWT expired at {}", e.getClaims().getExpiration());
+            return false;
+        } // 서명 불일치, 구조 손상, 잘못된 인자 등
+        catch (JwtException | IllegalArgumentException e) {
+            log.warn("Invalid JWT: {}", e.getMessage());
+            return false;
+        }
+    }
+
 }

--- a/src/test/java/com/example/workoutmate/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/example/workoutmate/domain/user/service/AuthServiceTest.java
@@ -46,7 +46,7 @@ class AuthServiceTest {
     @Test
     void 정상_회원가입() {
         // given
-        SignupRequestDto signupRequestDto = new SignupRequestDto("test@example.com", "Password!123", "테스트 유저", UserGender.Male);
+        SignupRequestDto signupRequestDto = new SignupRequestDto("test@example.com", "Password!123", "테스트 유저", UserGender.Male.toString());
 
         when(userRepository.existsByEmailAndIsDeletedFalseAndIsEmailVerifiedTrue(anyString())).thenReturn(false);
         when(userRepository.findByEmailAndIsDeletedFalseAndIsEmailVerifiedFalse(anyString())).thenReturn(Optional.empty());
@@ -128,15 +128,15 @@ class AuthServiceTest {
                 .role(UserRole.GUEST)
                 .build();
 
-        when(userRepository.findByEmailAndIsDeletedFalse(anyString())).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndIsDeletedFalseAndIsEmailVerifiedTrue(anyString())).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("Password!123", "encodedPW")).thenReturn(true);
-        when(jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole())).thenReturn("jwt.token");
+        when(jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getRole())).thenReturn("jwt.token");
 
         // when
         LoginResponseDto loginResponseDto = authService.login(loginRequestDto);
 
         // then
-        assertThat(loginResponseDto.getToken()).isEqualTo("jwt.token");
+        assertThat(loginResponseDto.getAccessToken()).isEqualTo("jwt.token");
 
     }
 


### PR DESCRIPTION
## 구현 사항
- jwt - access token 과 refresh token 을 구현하여 보안 강화
  - access token : 서비스 자원에 접근가능하게 하는 토큰
  - refresh token : access token 이 만료됐을 경우, 재발행을 위한 토큰
- 로그아웃 기능 구현 (blacklist 에 access token 의 jti(토큰 식별자)를 추가하여 로그아웃된 사용자 식별)
  - 토큰 만료일과 동일하게 레디스에 ttl 설정하여 blacklist 에 계속해서 데이터 쌓이지 않도록 구현 (만료된 토큰은 DB에서 삭제됨)
- refresh token의 식별자(jti)를 Redis 에 저장해 토큰 리프레시 가능하게 구현 (리프레시 할 경우 기존 access token, refresh token 모두가 새로 발급됨)
- jwtUtil 속 메서드 수정하며 해당 메서드 사용하는 다른 부분도 함께 수정

### 참고 사항
- 기존 코드에서 발견한 작은 오류들 개선
- 동작 흐름은 5분 기록보드에 작성해서 추가 할 예정
- 토큰 값이 아닌 jti (식별자)를 저장한 이유는 토큰이 탈취되었을 경우를 고려한 보안 강화를 위함
- api 추가됨 (작성중)