### PR TITLE
refactor(token): Bearer token과 refresh token 구분 위한 변수명 수정, 불필요한 메서드 삭제

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/workoutmate/domain/user/service/AuthService.java
@@ -4,7 +4,6 @@ import com.example.workoutmate.domain.user.dto.*;
 import com.example.workoutmate.domain.user.entity.User;
 import com.example.workoutmate.domain.user.entity.UserMapper;
 import com.example.workoutmate.domain.user.repository.UserRepository;
-import com.example.workoutmate.global.exception.JwtAccessDeniedHandler;
 import com.example.workoutmate.global.util.JwtUtil;
 import com.example.workoutmate.global.enums.CustomErrorCode;
 import com.example.workoutmate.global.exception.CustomException;
@@ -34,7 +33,6 @@ public class AuthService {
     private final EmailVerificationService emailVerificationService;
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
-    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final TokenBlacklistService tokenBlacklistService;
 
     @Transactional
@@ -155,13 +153,13 @@ public class AuthService {
     }
 
     // logout
-    public void logout(String accessToken, String refreshToken) {
+    public void logout(String bearerAccessToken, String refreshToken) {
         // accessToken 에서 Jti 추출
-        String accessTokenValue = jwtUtil.substringToken(accessToken);
-        String accessTokenJti = jwtUtil.getJti(accessTokenValue);
+        String accessToken = jwtUtil.substringToken(bearerAccessToken);
+        String accessTokenJti = jwtUtil.getJti(accessToken);
 
         // accessToken Jti를 블랙리스트에 추가 (만료시간까지 저장)
-        Date expiration = jwtUtil.getExpiration(accessTokenValue);
+        Date expiration = jwtUtil.getExpiration(accessToken);
         Duration remainingMillis = Duration.ofMillis(expiration.getTime() - System.currentTimeMillis());
         tokenBlacklistService.addToBlacklist(accessTokenJti, remainingMillis);
 

--- a/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
+++ b/src/main/java/com/example/workoutmate/global/util/JwtUtil.java
@@ -61,9 +61,9 @@ public class JwtUtil {
     }
 
     // Bearer 제거한 토큰 값만 추출
-    public String substringToken(String tokenValue) {
-        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
-            return tokenValue.substring(7);
+    public String substringToken(String bearerToken) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
         }
         throw new CustomException(CustomErrorCode.SERVER_EXCEPTION_JWT);
     }
@@ -98,27 +98,6 @@ public class JwtUtil {
                 .setIssuedAt(date)
                 .signWith(key, signatureAlgorithm)
                 .compact();
-    }
-
-    // 토큰 유효성 검증
-    public boolean validateAccessToken(String token) {
-        try {
-            Jws<Claims> claims = parseToken(token);
-            // 블랙리스트에 있는지 확인
-            String jti = claims.getBody().getId();
-            if (tokenBlacklistService.isBlacklisted(jti)) {
-                return false;
-            }
-            return true;
-        } // 토큰 만료
-        catch (ExpiredJwtException e) {
-            log.warn("JWT expired at {}", e.getClaims().getExpiration());
-            return false;
-        } // 서명 불일치, 구조 손상, 잘못된 인자 등
-        catch (JwtException | IllegalArgumentException e) {
-            log.warn("Invalid JWT: {}", e.getMessage());
-            return false;
-        }
     }
 
     // 리프레시 토큰 유효성 검증


### PR DESCRIPTION
### 수정 사항
- 불필요한 메서드 삭제
- Bearer 가 붙은 access token 과 붙지않은 refresh token 을 구분하기 위해 변수명 수정


### 참고사항
- refresh token 은 쿠키에 저장되는것이기 때문에 Bearer 접두어가 필요없다고 합니다.