### PR TITLE
feat(chatting): ping 전송 시 만료된 토큰 에러 처리 로직 추가

### DIFF
--- a/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
+++ b/src/main/java/com/example/workoutmate/domain/chatting/service/ChatMessageService.java
@@ -13,6 +13,8 @@ import com.example.workoutmate.global.config.CustomUserPrincipal;
 import com.example.workoutmate.global.exception.CustomException;
 import com.example.workoutmate.global.util.JwtUtil;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,11 +59,23 @@ public class ChatMessageService {
 
 
     public void sendPingError(String token, CustomUserPrincipal authUser) {
-        Claims claims = jwtUtil.parseToken(jwtUtil.substringToken(token)).getBody();
-        String email = claims.get("email", String.class);
+        try {
+            Claims claims = jwtUtil.parseToken(jwtUtil.substringToken(token)).getBody();
+            String email = claims.get("email", String.class);
 
-        if (!email.equals(authUser.getEmail())) {
-            throw new CustomException(TOKEN_USER_MISMATCH, TOKEN_USER_MISMATCH.getMessage() + " 다시 로그인해주세요.");
+            if (!email.equals(authUser.getEmail())) {
+                throw new CustomException(TOKEN_USER_MISMATCH, TOKEN_USER_MISMATCH.getMessage() + " 다시 로그인해주세요.");
+            }
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(
+                    EXPIRED_JWT_TOKEN,
+                    EXPIRED_JWT_TOKEN.getMessage() + "다시 로그인해주세요."
+            );
+        } catch (JwtException e) {
+            throw new CustomException(
+                    SC_UNAUTHORIZED,
+                    SC_UNAUTHORIZED.getMessage() + "다시 로그인해주세요."
+            );
         }
     }
 }


### PR DESCRIPTION
### **📌 개요**
ping 전송 시 만료된 토큰 에러 처리 로직 추가

### **✅ 작업 사항**
클라이언트에서 주기적으로 ping으로 jwt 토큰 전송 후
서버에서 만료된 토큰에 대한 에러 처리 로직 추가

### **🔍 리뷰 요청 포인트**
### **💬 기타 사항**
로컬에서는 정상 동작 확인했습니다
<img width="697" height="283" alt="image" src="https://github.com/user-attachments/assets/c036bfed-30c8-4557-9e2e-a0da8978f674" />
